### PR TITLE
Normalize autocorrelation output

### DIFF
--- a/PQEnalyzer/statistics/statistic.py
+++ b/PQEnalyzer/statistics/statistic.py
@@ -46,7 +46,7 @@ class Statistic:
     >>> Statistic.cumulative_average(energies, "ENERGY")
     ([1, 2, 3, 4, 5], [1, 1.5, 2, 2.5, 3])
     >>> Statistic.auto_correlation(energies, "ENERGY")
-    ([1, 2, 3, 4, 5], [2.1666, 2.8571, 3.6666, 4., 4.3333])
+    ([1, 2, 3, 4, 5], [1., 0.4, -0.1, -0.4, -0.4])
     >>> Statistic.running_average(energies, "ENERGY", 2)
     ([1.5, 2.5, 3.5, 4.5], [10.5, 11.5, 12.5, 13.5])
     """
@@ -161,7 +161,7 @@ class Statistic:
     @staticmethod
     def auto_correlation(energies, info_parameter) -> tuple:
         """
-        Calculate the auto correlation of the data.
+        Calculate the normalized autocorrelation of the data.
 
         Parameters
         ----------
@@ -173,20 +173,30 @@ class Statistic:
         Returns
         -------
         tuple
-            A tuple containing the time and auto correlation of the data.
+            A tuple containing the time and normalized autocorrelation data.
 
         Examples
         --------
         >>> Statistic.auto_correlation(energies, "ENERGY")
-        ([1, 2, 3, 4, 5], [2.1666, 2.8571, 3.6666, 4., 4.3333])
+        ([1, 2, 3, 4, 5], [1., 0.4, -0.1, -0.4, -0.4])
         """
 
-        data = np.concatenate(
-            [energy.data[energy.info[info_parameter]] for energy in energies])
+        data = np.concatenate([
+            energy.data[energy.info[info_parameter]]
+            for energy in energies
+        ]).astype(float)
 
-        auto_correlation = np.correlate(
-            data, data, mode="same") / np.correlate(
-                np.ones_like(data), data, mode="same")
+        centered_data = data - np.mean(data)
+        zero_lag_correlation = np.dot(centered_data, centered_data)
+
+        if zero_lag_correlation == 0:
+            auto_correlation = np.zeros_like(data)
+            auto_correlation[0] = 1
+        else:
+            auto_correlation = (
+                np.correlate(centered_data, centered_data,
+                             mode="full")[len(data) - 1:] /
+                zero_lag_correlation)
 
         time = np.concatenate([energy.simulation_time for energy in energies])
 

--- a/tests/statistics/test_statistic.py
+++ b/tests/statistics/test_statistic.py
@@ -64,17 +64,22 @@ class TestStatistic:
         time, auto_correlation = Statistic.auto_correlation(
             energies, "SIMULATION-TIME")
         assert np.all(time == [1, 2, 3, 4, 5])
-        assert np.allclose(auto_correlation,
-                           [2.1666, 2.8571, 3.6666, 4., 4.3333],
-                           rtol=1e-4)
+        assert np.allclose(auto_correlation, [1, 0.4, -0.1, -0.4, -0.4])
 
         energies2 = Reader(["tests/data/md-02.en"], MDEngineFormat.PQ).energies
         time, auto_correlation = Statistic.auto_correlation(
             energies2, "SIMULATION-TIME")
         assert np.all(time == [6, 7, 8, 9, 10])
-        assert np.allclose(auto_correlation,
-                           [7.0741, 7.6471, 8.25, 8.6666, 9.0952],
-                           rtol=1e-4)
+        assert np.allclose(auto_correlation, [1, 0.4, -0.1, -0.4, -0.4])
+
+    def test_auto_correlation_constant_data(self):
+        energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
+
+        time, auto_correlation = Statistic.auto_correlation(
+            energies, "E(INTRA)")
+
+        assert np.all(time == [1, 2, 3, 4, 5])
+        assert np.all(auto_correlation == [1, 0, 0, 0, 0])
 
     def test_running_average(self):
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies


### PR DESCRIPTION
## Summary
- Replace the previous raw same-mode autocorrelation calculation with a mean-centered, zero-lag-normalized autocorrelation.
- Preserve the existing return shape by returning the original simulation-time array with the normalized autocorrelation values.
- Handle constant input series with a finite zero-lag result of 1 followed by zeros, avoiding NaN output for flat parameters.
- Update statistics tests for normalized output and constant-data behavior.

## Validation
- Statistics tests pass: 8 passed.
- Coverage command passes with 100% project coverage: 23 passed, 2 skipped, 110/110 covered.
- Package distribution build succeeds.

## Behavior change
This changes `Statistic.auto_correlation` output values. The first value is now 1.0 for non-constant data, which is the conventional normalized autocorrelation at zero lag.
