### PR TITLE
Route runtime messages through logging

### DIFF
--- a/PQEnalyzer/__main__.py
+++ b/PQEnalyzer/__main__.py
@@ -8,6 +8,10 @@ import argparse
 import argcomplete
 
 from . import __version__
+from ._logging import configure_logging, get_logger
+
+
+logger = get_logger(__name__)
 
 
 def main():
@@ -48,6 +52,7 @@ def main():
     argcomplete.autocomplete(parser)
 
     args = parser.parse_args()
+    configure_logging()
 
     from PQAnalysis.traj import MDEngineFormat
 
@@ -63,7 +68,8 @@ def main():
     try:
         reader = Reader(args.filenames, md_format)
     except Exception as e:
-        print(e)
+        if not e.__class__.__module__.startswith("PQAnalysis"):
+            logger.error("%s", e)
         sys.exit(1)
 
     # if the user wants to use the terminal plotting feature

--- a/PQEnalyzer/_logging.py
+++ b/PQEnalyzer/_logging.py
@@ -10,11 +10,11 @@ import sys
 PACKAGE_LOGGER_NAME = "PQEnalyzer"
 RESET_COLOR = "\033[0m"
 LEVEL_COLORS = {
-    logging.DEBUG: "\033[2m",
-    logging.INFO: "\033[34m",
-    logging.WARNING: "\033[33m",
-    logging.ERROR: "\033[31m",
-    logging.CRITICAL: "\033[1;31m",
+    logging.DEBUG: "\033[2;38;5;245m",
+    logging.INFO: "\033[38;5;75m",
+    logging.WARNING: "\033[38;5;214m",
+    logging.ERROR: "\033[38;5;203m",
+    logging.CRITICAL: "\033[1;38;5;199m",
 }
 
 
@@ -28,13 +28,19 @@ class RuntimeFormatter(logging.Formatter):
         self.use_color = use_color
 
     def format(self, record):
-        message = super().format(record)
-
         if not self.use_color:
-            return message
+            return super().format(record)
 
         color = LEVEL_COLORS.get(record.levelno)
-        return f"{color}{message}{RESET_COLOR}" if color else message
+        if not color:
+            return super().format(record)
+
+        original_levelname = record.levelname
+        record.levelname = f"{color}{original_levelname}{RESET_COLOR}"
+        try:
+            return super().format(record)
+        finally:
+            record.levelname = original_levelname
 
 
 def get_logger(name=None):

--- a/PQEnalyzer/_logging.py
+++ b/PQEnalyzer/_logging.py
@@ -3,9 +3,38 @@ Logging helpers for PQEnalyzer runtime messages.
 """
 
 import logging
+import os
+import sys
 
 
 PACKAGE_LOGGER_NAME = "PQEnalyzer"
+RESET_COLOR = "\033[0m"
+LEVEL_COLORS = {
+    logging.DEBUG: "\033[2m",
+    logging.INFO: "\033[34m",
+    logging.WARNING: "\033[33m",
+    logging.ERROR: "\033[31m",
+    logging.CRITICAL: "\033[1;31m",
+}
+
+
+class RuntimeFormatter(logging.Formatter):
+    """
+    Format user-facing runtime messages with optional ANSI colors.
+    """
+
+    def __init__(self, use_color=False):
+        super().__init__("%(levelname)s: %(message)s")
+        self.use_color = use_color
+
+    def format(self, record):
+        message = super().format(record)
+
+        if not self.use_color:
+            return message
+
+        color = LEVEL_COLORS.get(record.levelno)
+        return f"{color}{message}{RESET_COLOR}" if color else message
 
 
 def get_logger(name=None):
@@ -25,4 +54,17 @@ def configure_logging(level=logging.INFO):
     """
     Configure user-facing CLI logging if the application has no handlers yet.
     """
-    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
+    stream = sys.stderr
+    use_color = _should_use_color(stream)
+    handler = logging.StreamHandler(stream)
+    handler.setFormatter(RuntimeFormatter(use_color=use_color))
+
+    logging.basicConfig(level=level, handlers=[handler])
+
+
+def _should_use_color(stream):
+    """
+    Return whether ANSI colors should be emitted for the given stream.
+    """
+    return ("NO_COLOR" not in os.environ and hasattr(stream, "isatty")
+            and stream.isatty())

--- a/PQEnalyzer/_logging.py
+++ b/PQEnalyzer/_logging.py
@@ -1,0 +1,28 @@
+"""
+Logging helpers for PQEnalyzer runtime messages.
+"""
+
+import logging
+
+
+PACKAGE_LOGGER_NAME = "PQEnalyzer"
+
+
+def get_logger(name=None):
+    """
+    Return a package logger for the given module or component name.
+    """
+    if name in {None, "", PACKAGE_LOGGER_NAME}:
+        return logging.getLogger(PACKAGE_LOGGER_NAME)
+
+    if name.startswith(f"{PACKAGE_LOGGER_NAME}."):
+        return logging.getLogger(name)
+
+    return logging.getLogger(f"{PACKAGE_LOGGER_NAME}.{name}")
+
+
+def configure_logging(level=logging.INFO):
+    """
+    Configure user-facing CLI logging if the application has no handlers yet.
+    """
+    logging.basicConfig(level=level, format="%(levelname)s: %(message)s")

--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -12,7 +12,11 @@ from PIL import Image, ImageTk
 import matplotlib.pyplot as plt
 
 from .. import __base__
+from .._logging import get_logger
 from ..plots import PlotTime, PlotHistogram
+
+
+logger = get_logger(__name__)
 
 
 class App(ctk.CTk):
@@ -426,7 +430,7 @@ class App(ctk.CTk):
                 interval = self.parse_positive_float(
                     self.interval.get(), 1.0, "Interval")
             except ValueError as error:
-                print(error)
+                logger.warning("%s", error)
                 return None
 
         plot = plot_factory(self)

--- a/PQEnalyzer/plots/plot_histogram.py
+++ b/PQEnalyzer/plots/plot_histogram.py
@@ -7,7 +7,11 @@ from scipy.stats import gaussian_kde
 import numpy as np
 
 from ..statistics import Statistic
+from .._logging import get_logger
 from .plot import Plot
+
+
+logger = get_logger(__name__)
 
 
 class PlotHistogram(Plot):
@@ -67,9 +71,7 @@ class PlotHistogram(Plot):
 
             # check if zero data
             if np.unique(data).size == 1:
-                # raise warning if no data to plot
-                # TODO: change to logger
-                print("Data zero. No histogram available.")
+                logger.warning("Data zero. No histogram available.")
                 continue
 
             # plot kde of histogram
@@ -110,10 +112,7 @@ class PlotHistogram(Plot):
 
         # Check if label is empty
         if self.ax.get_legend_handles_labels()[1] == []:
-            # raise warning if no data to plot
-            # TODO: change to logger
-            # raise RuntimeWarning("No data to plot.")
-            print("No data to plot.")
+            logger.warning("No data to plot.")
         else:
             # legend outside of plot
             self.ax.legend(

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -4,7 +4,11 @@ for the PQEnalyzer application.
 """
 
 from ..statistics import Statistic
+from .._logging import get_logger
 from .plot import Plot
+
+
+logger = get_logger(__name__)
 
 
 class PlotTime(Plot):
@@ -91,10 +95,7 @@ class PlotTime(Plot):
 
         # Check if label is empty
         if self.ax.get_legend_handles_labels()[1] == []:
-            # raise warning if no data to plot
-            # TODO: change to logger
-            # raise RuntimeWarning("No data to plot.")
-            print("No data to plot.")
+            logger.warning("No data to plot.")
         else:
             # legend outside of plot
             self.ax.legend(
@@ -168,8 +169,7 @@ class PlotTime(Plot):
                                                   info_parameter,
                                                   window_size_int)
             except ValueError as error:
-                # raise warning if window size is too large
-                print(error)
+                logger.warning("%s", error)
                 return None
 
             self.ax.plot(

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -137,7 +137,7 @@ def test_destroy_closes_plots_and_tk_window(monkeypatch):
     assert calls == [("close", "all"), ("quit", None), ("destroy", None)]
 
 
-def test_plot_button_rejects_invalid_follow_interval(monkeypatch, capsys):
+def test_plot_button_rejects_invalid_follow_interval(monkeypatch, caplog):
     app = make_app(follow=True, interval="0")
     monkeypatch.setattr(app_module, "PlotTime", DummyPlot)
 
@@ -145,7 +145,7 @@ def test_plot_button_rejects_invalid_follow_interval(monkeypatch, capsys):
 
     assert app.list_of_plots == []
     assert DummyPlot.instances == []
-    assert "Interval must be greater than zero" in capsys.readouterr().out
+    assert "Interval must be greater than zero" in caplog.text
 
 
 def test_plot_button_passes_valid_follow_interval(monkeypatch):

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -69,14 +69,14 @@ def teardown_function():
     plt.close("all")
 
 
-def test_histogram_skips_constant_series_and_plots_remaining_data(capsys):
+def test_histogram_skips_constant_series_and_plots_remaining_data(caplog):
     app = FakeApp([FakeEnergy([1, 1, 1, 1]), FakeEnergy([1, 2, 3, 4])])
     plot = PlotHistogram(app)
 
     plot.main_data("PARAMETER")
 
     assert plot.ax.get_legend_handles_labels()[1] == ["series-1.en KDE"]
-    assert "Data zero. No histogram available." in capsys.readouterr().out
+    assert "Data zero. No histogram available." in caplog.text
 
 
 def test_histogram_statistics_draw_single_mean_and_median_lines():
@@ -90,7 +90,7 @@ def test_histogram_statistics_draw_single_mean_and_median_lines():
     assert len(plot.ax.collections[1].get_segments()) == 1
 
 
-def test_running_average_rejects_invalid_window_size_without_crashing(capsys):
+def test_running_average_rejects_invalid_window_size_without_crashing(caplog):
     app = FakeApp([FakeEnergy([1, 2, 3, 4])],
                   running_average=True,
                   window_size="0")
@@ -98,4 +98,4 @@ def test_running_average_rejects_invalid_window_size_without_crashing(capsys):
 
     plot.statistics("PARAMETER")
 
-    assert "Window size must be positive" in capsys.readouterr().out
+    assert "Window size must be positive" in caplog.text

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,3 +17,50 @@ def test_cli_version_from_source_checkout():
     assert result.returncode == 0
     assert "Traceback" not in result.stderr
     assert result.stdout.startswith("PQEnalyzer ")
+
+
+def test_cli_logs_reader_validation_errors():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "PQEnalyzer",
+            "--no-gui",
+            "tests/data/md-01.en",
+            "tests/data/md-02.en",
+        ],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "ERROR: The energy files do not have the same info parameters" in (
+        result.stderr)
+
+
+def test_cli_does_not_duplicate_upstream_reader_errors():
+    project_root = Path(__file__).resolve().parents[1]
+    missing_file = "tests/data/does-not-exist.en"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "PQEnalyzer",
+            "--no-gui",
+            missing_file,
+        ],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert result.stderr.count(f"File {missing_file} not found.") == 1

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,6 +1,6 @@
 import logging
 
-from PQEnalyzer._logging import (RESET_COLOR, RuntimeFormatter,
+from PQEnalyzer._logging import (LEVEL_COLORS, RESET_COLOR, RuntimeFormatter,
                                  PACKAGE_LOGGER_NAME, configure_logging,
                                  get_logger)
 
@@ -42,10 +42,13 @@ def make_record(level, message):
 
 def test_runtime_formatter_colorizes_by_level():
     formatter = RuntimeFormatter(use_color=True)
+    record = make_record(logging.WARNING, "Careful")
 
-    message = formatter.format(make_record(logging.WARNING, "Careful"))
+    message = formatter.format(record)
 
-    assert message == f"\033[33mWARNING: Careful{RESET_COLOR}"
+    assert message == (
+        f"{LEVEL_COLORS[logging.WARNING]}WARNING{RESET_COLOR}: Careful")
+    assert record.levelname == "WARNING"
 
 
 def test_runtime_formatter_can_disable_color():
@@ -54,6 +57,14 @@ def test_runtime_formatter_can_disable_color():
     message = formatter.format(make_record(logging.ERROR, "Failed"))
 
     assert message == "ERROR: Failed"
+
+
+def test_runtime_formatter_leaves_unknown_levels_plain():
+    formatter = RuntimeFormatter(use_color=True)
+
+    message = formatter.format(make_record(35, "Custom"))
+
+    assert message == "Level 35: Custom"
 
 
 def test_configure_logging_delegates_to_standard_logging(monkeypatch):
@@ -72,7 +83,8 @@ def test_configure_logging_delegates_to_standard_logging(monkeypatch):
     assert calls[0]["level"] == logging.DEBUG
     assert handler.stream is fake_stream
     assert handler.formatter.format(make_record(
-        logging.ERROR, "Failed")) == f"\033[31mERROR: Failed{RESET_COLOR}"
+        logging.ERROR,
+        "Failed")) == f"{LEVEL_COLORS[logging.ERROR]}ERROR{RESET_COLOR}: Failed"
 
 
 def test_configure_logging_respects_no_color(monkeypatch):

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,23 @@
 import logging
 
-from PQEnalyzer._logging import (PACKAGE_LOGGER_NAME, configure_logging,
+from PQEnalyzer._logging import (RESET_COLOR, RuntimeFormatter,
+                                 PACKAGE_LOGGER_NAME, configure_logging,
                                  get_logger)
+
+
+class FakeStream:
+
+    def __init__(self, is_tty):
+        self.is_tty = is_tty
+
+    def flush(self):
+        return None
+
+    def isatty(self):
+        return self.is_tty
+
+    def write(self, message):
+        return len(message)
 
 
 def test_get_logger_returns_package_logger_names():
@@ -12,15 +28,65 @@ def test_get_logger_returns_package_logger_names():
     assert get_logger("PQEnalyzer.apps.app").name == "PQEnalyzer.apps.app"
 
 
+def make_record(level, message):
+    return logging.LogRecord(
+        name="PQEnalyzer.tests",
+        level=level,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_runtime_formatter_colorizes_by_level():
+    formatter = RuntimeFormatter(use_color=True)
+
+    message = formatter.format(make_record(logging.WARNING, "Careful"))
+
+    assert message == f"\033[33mWARNING: Careful{RESET_COLOR}"
+
+
+def test_runtime_formatter_can_disable_color():
+    formatter = RuntimeFormatter(use_color=False)
+
+    message = formatter.format(make_record(logging.ERROR, "Failed"))
+
+    assert message == "ERROR: Failed"
+
+
 def test_configure_logging_delegates_to_standard_logging(monkeypatch):
     calls = []
+    fake_stream = FakeStream(is_tty=True)
 
     monkeypatch.setattr(logging, "basicConfig",
                         lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr("sys.stderr", fake_stream)
+    monkeypatch.delenv("NO_COLOR", raising=False)
 
     configure_logging(logging.DEBUG)
 
-    assert calls == [{
-        "level": logging.DEBUG,
-        "format": "%(levelname)s: %(message)s",
-    }]
+    handler = calls[0]["handlers"][0]
+
+    assert calls[0]["level"] == logging.DEBUG
+    assert handler.stream is fake_stream
+    assert handler.formatter.format(make_record(
+        logging.ERROR, "Failed")) == f"\033[31mERROR: Failed{RESET_COLOR}"
+
+
+def test_configure_logging_respects_no_color(monkeypatch):
+    calls = []
+    fake_stream = FakeStream(is_tty=True)
+
+    monkeypatch.setattr(logging, "basicConfig",
+                        lambda **kwargs: calls.append(kwargs))
+    monkeypatch.setattr("sys.stderr", fake_stream)
+    monkeypatch.setenv("NO_COLOR", "1")
+
+    configure_logging()
+
+    handler = calls[0]["handlers"][0]
+
+    assert handler.formatter.format(make_record(logging.ERROR,
+                                                "Failed")) == "ERROR: Failed"

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,26 @@
+import logging
+
+from PQEnalyzer._logging import (PACKAGE_LOGGER_NAME, configure_logging,
+                                 get_logger)
+
+
+def test_get_logger_returns_package_logger_names():
+    assert get_logger().name == PACKAGE_LOGGER_NAME
+    assert get_logger("").name == PACKAGE_LOGGER_NAME
+    assert get_logger(PACKAGE_LOGGER_NAME).name == PACKAGE_LOGGER_NAME
+    assert get_logger("plots").name == "PQEnalyzer.plots"
+    assert get_logger("PQEnalyzer.apps.app").name == "PQEnalyzer.apps.app"
+
+
+def test_configure_logging_delegates_to_standard_logging(monkeypatch):
+    calls = []
+
+    monkeypatch.setattr(logging, "basicConfig",
+                        lambda **kwargs: calls.append(kwargs))
+
+    configure_logging(logging.DEBUG)
+
+    assert calls == [{
+        "level": logging.DEBUG,
+        "format": "%(levelname)s: %(message)s",
+    }]


### PR DESCRIPTION
## Summary
- Add a package logging helper for consistent runtime messages
- Replace GUI and plot warning prints with logger warnings
- Log CLI validation errors while avoiding duplicate messages from upstream reader errors
- Color terminal log level labels with a modern 256-color palette when stderr is interactive, while respecting NO_COLOR and non-TTY output
- Update warning tests to assert log records, stderr behavior, and formatter behavior

Closes #23

## Validation
- python -m pytest -q tests/test_logging.py tests/apps tests/plots
- python -m pytest -q tests/test_cli.py
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing --cov-report=xml
- python -m pytest -q -m e2e
- python -m pytest -q
- python -m build