### PR TITLE
Refactor energy parameter access

### DIFF
--- a/PQEnalyzer/energy_access.py
+++ b/PQEnalyzer/energy_access.py
@@ -1,0 +1,98 @@
+"""
+Helpers for reading PQAnalysis energy data through its public API.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+PARAMETER_ATTRIBUTES = {
+    "SIMULATION-TIME": "simulation_time",
+    "TEMPERATURE": "temperature",
+    "PRESSURE": "pressure",
+    "E(TOT)": "total_energy",
+    "E(QM)": "qm_energy",
+    "N(QM-ATOMS)": "number_of_qm_atoms",
+    "E(KIN)": "kinetic_energy",
+    "E(INTRA)": "intramolecular_energy",
+    "VOLUME": "volume",
+    "DENSITY": "density",
+    "MOMENTUM": "momentum",
+    "LOOPTIME": "looptime",
+}
+
+
+@dataclass(frozen=True)
+class EnergySeries:
+    """
+    Normalized view of a single energy parameter and its time axis.
+    """
+
+    time: np.ndarray
+    values: np.ndarray
+    label: str
+    unit: str
+
+
+def parameter_values(energy, info_parameter: str) -> np.ndarray:
+    """
+    Return a parameter array, preferring PQAnalysis public Energy attributes.
+    """
+
+    attribute = PARAMETER_ATTRIBUTES.get(info_parameter)
+    if attribute is not None and hasattr(energy, attribute):
+        return np.asarray(getattr(energy, attribute))
+
+    return np.asarray(energy.data[energy.info[info_parameter]])
+
+
+def parameter_unit(energy, info_parameter: str) -> str:
+    """
+    Return a parameter unit, preferring PQAnalysis public unit attributes.
+    """
+
+    attribute = PARAMETER_ATTRIBUTES.get(info_parameter)
+    unit_attribute = f"{attribute}_unit"
+    if attribute is not None and hasattr(energy, unit_attribute):
+        return getattr(energy, unit_attribute)
+
+    return energy.units[info_parameter]
+
+
+def simulation_time(energy) -> np.ndarray:
+    """
+    Return the simulation time axis from a PQAnalysis Energy object.
+    """
+
+    return np.asarray(energy.simulation_time)
+
+
+def series(energy, info_parameter: str) -> EnergySeries:
+    """
+    Return a normalized parameter series for plotting.
+    """
+
+    return EnergySeries(
+        time=simulation_time(energy),
+        values=parameter_values(energy, info_parameter),
+        label=info_parameter,
+        unit=parameter_unit(energy, info_parameter),
+    )
+
+
+def concatenate_time(energies: list) -> np.ndarray:
+    """
+    Concatenate simulation time arrays from multiple energy files.
+    """
+
+    return np.concatenate([simulation_time(energy) for energy in energies])
+
+
+def concatenate_parameter(energies: list, info_parameter: str) -> np.ndarray:
+    """
+    Concatenate one parameter from multiple energy files.
+    """
+
+    return np.concatenate(
+        [parameter_values(energy, info_parameter) for energy in energies])

--- a/PQEnalyzer/plots/plot_histogram.py
+++ b/PQEnalyzer/plots/plot_histogram.py
@@ -7,6 +7,7 @@ from scipy.stats import gaussian_kde
 import numpy as np
 
 from ..statistics import Statistic
+from ..energy_access import parameter_unit, parameter_values
 from .._logging import get_logger
 from .plot import Plot
 
@@ -67,7 +68,7 @@ class PlotHistogram(Plot):
 
         for i, energy in enumerate(self.reader.energies):
             basename = os.path.basename(self.reader.filenames[i])
-            data = energy.data[energy.info[info_parameter]]
+            data = parameter_values(energy, info_parameter)
 
             # check if zero data
             if np.unique(data).size == 1:
@@ -75,11 +76,11 @@ class PlotHistogram(Plot):
                 continue
 
             # plot kde of histogram
-            kde = gaussian_kde(energy.data[energy.info[info_parameter]])
+            kde = gaussian_kde(data)
 
             x = np.linspace(
-                min(energy.data[energy.info[info_parameter]]),
-                max(energy.data[energy.info[info_parameter]]),
+                min(data),
+                max(data),
                 1000,
             )
 
@@ -107,7 +108,8 @@ class PlotHistogram(Plot):
         self.ax.ticklabel_format(axis="both", style="sci")
 
         self.ax.set_xlabel(
-            f"{info_parameter} / {self.reader.energies[0].units[info_parameter]}"
+            f"{info_parameter} / "
+            f"{parameter_unit(self.reader.energies[0], info_parameter)}"
         )
 
         # Check if label is empty

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -4,6 +4,7 @@ for the PQEnalyzer application.
 """
 
 from ..statistics import Statistic
+from ..energy_access import parameter_unit, series
 from .._logging import get_logger
 from .plot import Plot
 
@@ -64,12 +65,13 @@ class PlotTime(Plot):
         """
 
         for i, energy in enumerate(self.reader.energies):
+            energy_series = series(energy, info_parameter)
             self.ax.plot(
-                energy.simulation_time,
-                energy.data[energy.info[info_parameter]],
+                energy_series.time,
+                energy_series.values,
                 label=self.reader.filenames[i],
             )
-        self.add_value_label(energy.simulation_time, energy.data[energy.info[info_parameter]])
+        self.add_value_label(energy_series.time, energy_series.values)
 
     def labels(self, info_parameter: str) -> None:
         """
@@ -90,7 +92,8 @@ class PlotTime(Plot):
         self.ax.ticklabel_format(axis="both", style="sci")
 
         self.ax.set_ylabel(
-            f"{info_parameter} / {self.reader.energies[0].units[info_parameter]}"
+            f"{info_parameter} / "
+            f"{parameter_unit(self.reader.energies[0], info_parameter)}"
         )
 
         # Check if label is empty

--- a/PQEnalyzer/plots/termplot.py
+++ b/PQEnalyzer/plots/termplot.py
@@ -5,6 +5,8 @@ The plot module to plot the data in the terminal.
 import os
 import plotext as plt
 
+from ..energy_access import parameter_unit, series
+
 
 class TermPlot:
     """
@@ -52,14 +54,16 @@ class TermPlot:
         """
         for i, energy in enumerate(self.reader.energies):
             basename = os.path.basename(self.reader.filenames[i])
+            energy_series = series(energy, info_parameter)
             plt.plot(
-                energy.simulation_time,
-                energy.data[energy.info[info_parameter]],
+                energy_series.time,
+                energy_series.values,
                 label=basename,
             )
             plt.xlabel("Simulation Time")
             plt.ylabel(
-                f"{info_parameter} / {self.reader.energies[0].units[info_parameter]}"
+                f"{info_parameter} / "
+                f"{parameter_unit(self.reader.energies[0], info_parameter)}"
             )
         plt.show()
         plt.clear_figure()

--- a/PQEnalyzer/statistics/statistic.py
+++ b/PQEnalyzer/statistics/statistic.py
@@ -5,6 +5,8 @@ methods to calculate statistics of the data.
 
 import numpy as np
 
+from ..energy_access import concatenate_parameter, concatenate_time
+
 
 class Statistic:
     """
@@ -77,10 +79,8 @@ class Statistic:
         ([1, 5], [1.0, 1.0])
         """
 
-        time = np.concatenate([energy.simulation_time for energy in energies])
-
-        data = np.concatenate(
-            [energy.data[energy.info[info_parameter]] for energy in energies])
+        time = concatenate_time(energies)
+        data = concatenate_parameter(energies, info_parameter)
 
         mean = np.mean(data)
 
@@ -109,10 +109,8 @@ class Statistic:
         ([1, 5], [1.0, 1.0])
         """
 
-        time = np.concatenate([energy.simulation_time for energy in energies])
-
-        data = np.concatenate(
-            [energy.data[energy.info[info_parameter]] for energy in energies])
+        time = concatenate_time(energies)
+        data = concatenate_parameter(energies, info_parameter)
 
         median = np.median(data)
 
@@ -141,12 +139,11 @@ class Statistic:
         ([1, 2, 3, 4, 5], [2.1666, 2.8571, 3.6666, 4., 4.3333])
         """
 
-        data = np.concatenate(
-            [energy.data[energy.info[info_parameter]] for energy in energies])
+        data = concatenate_parameter(energies, info_parameter)
 
         cumulative_average = np.cumsum(data) / np.arange(1, len(data) + 1)
 
-        time = np.concatenate([energy.simulation_time for energy in energies])
+        time = concatenate_time(energies)
 
         return time, cumulative_average
 
@@ -181,10 +178,7 @@ class Statistic:
         ([1, 2, 3, 4, 5], [1., 0.4, -0.1, -0.4, -0.4])
         """
 
-        data = np.concatenate([
-            energy.data[energy.info[info_parameter]]
-            for energy in energies
-        ]).astype(float)
+        data = concatenate_parameter(energies, info_parameter).astype(float)
 
         centered_data = data - np.mean(data)
         zero_lag_correlation = np.dot(centered_data, centered_data)
@@ -198,7 +192,7 @@ class Statistic:
                              mode="full")[len(data) - 1:] /
                 zero_lag_correlation)
 
-        time = np.concatenate([energy.simulation_time for energy in energies])
+        time = concatenate_time(energies)
 
         return time, auto_correlation
 
@@ -233,8 +227,7 @@ class Statistic:
         ([1.5, 2.5, 3.5, 4.5], [10.5, 11.5, 12.5, 13.5])
         """
 
-        data = np.concatenate(
-            [energy.data[energy.info[info_parameter]] for energy in energies])
+        data = concatenate_parameter(energies, info_parameter)
 
         if window_size < 1:
             raise ValueError("Window size must be positive")
@@ -249,7 +242,7 @@ class Statistic:
         ])
 
         # Centered to the middle of the window
-        time = np.concatenate([energy.simulation_time for energy in energies])
+        time = concatenate_time(energies)
         time = np.array([
             np.mean(time[i:i + window_size])
             for i in range(len(data) - window_size + 1)

--- a/tests/test_energy_access.py
+++ b/tests/test_energy_access.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from PQAnalysis.io import EnergyFileReader
+from PQAnalysis.traj import MDEngineFormat
+
+from PQEnalyzer.energy_access import (
+    concatenate_parameter,
+    concatenate_time,
+    parameter_unit,
+    parameter_values,
+    series,
+    simulation_time,
+)
+
+
+class CustomEnergy:
+
+    def __init__(self):
+        self.info = {"CUSTOM": "CUSTOM"}
+        self.units = {"CUSTOM": "arb"}
+        self.data = {"CUSTOM": np.array([10.0, 11.0, 12.0])}
+        self.simulation_time = np.array([1.0, 2.0, 3.0])
+
+
+def read_energy(filename):
+    return EnergyFileReader(filename,
+                            engine_format=MDEngineFormat.PQ).read()
+
+
+def test_parameter_access_prefers_pqanalysis_public_attributes():
+    energy = read_energy("tests/data/md-02.en")
+
+    np.testing.assert_array_equal(parameter_values(energy, "TEMPERATURE"),
+                                  energy.temperature)
+    assert parameter_unit(energy, "TEMPERATURE") == energy.temperature_unit
+
+    energy_series = series(energy, "TEMPERATURE")
+    np.testing.assert_array_equal(energy_series.time,
+                                  energy.simulation_time)
+    np.testing.assert_array_equal(energy_series.values, energy.temperature)
+    assert energy_series.label == "TEMPERATURE"
+    assert energy_series.unit == energy.temperature_unit
+
+
+def test_parameter_access_keeps_custom_parameter_fallback():
+    energy = CustomEnergy()
+
+    np.testing.assert_array_equal(parameter_values(energy, "CUSTOM"),
+                                  np.array([10.0, 11.0, 12.0]))
+    assert parameter_unit(energy, "CUSTOM") == "arb"
+    np.testing.assert_array_equal(simulation_time(energy),
+                                  np.array([1.0, 2.0, 3.0]))
+
+
+def test_concatenate_helpers_join_series_from_multiple_energy_files():
+    energies = [
+        read_energy("tests/data/md-01.en"),
+        read_energy("tests/data/md-02.en"),
+    ]
+
+    np.testing.assert_array_equal(concatenate_time(energies),
+                                  np.arange(1, 11))
+    np.testing.assert_array_equal(
+        concatenate_parameter(energies, "SIMULATION-TIME"),
+        np.arange(1, 11),
+    )


### PR DESCRIPTION
## Summary
- add a small energy access layer that prefers PQAnalysis public Energy attributes
- route statistics, GUI plots, histograms, and terminal plots through the shared accessor
- cover public PQAnalysis access and custom-parameter fallback behavior

## Verification
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing
- python -m pytest
- python -m build