### PR TITLE
Refactor statistics around numeric series

### DIFF
--- a/PQEnalyzer/energy_access.py
+++ b/PQEnalyzer/energy_access.py
@@ -96,3 +96,16 @@ def concatenate_parameter(energies: list, info_parameter: str) -> np.ndarray:
 
     return np.concatenate(
         [parameter_values(energy, info_parameter) for energy in energies])
+
+
+def concatenate_series(energies: list, info_parameter: str) -> EnergySeries:
+    """
+    Return one normalized parameter series across multiple energy files.
+    """
+
+    return EnergySeries(
+        time=concatenate_time(energies),
+        values=concatenate_parameter(energies, info_parameter),
+        label=info_parameter,
+        unit=parameter_unit(energies[0], info_parameter),
+    )

--- a/PQEnalyzer/statistics/statistic.py
+++ b/PQEnalyzer/statistics/statistic.py
@@ -5,7 +5,7 @@ methods to calculate statistics of the data.
 
 import numpy as np
 
-from ..energy_access import concatenate_parameter, concatenate_time
+from ..energy_access import concatenate_series
 
 
 class Statistic:
@@ -79,12 +79,19 @@ class Statistic:
         ([1, 5], [1.0, 1.0])
         """
 
-        time = concatenate_time(energies)
-        data = concatenate_parameter(energies, info_parameter)
+        energy_series = concatenate_series(energies, info_parameter)
+        return Statistic.mean_values(energy_series.time, energy_series.values)
 
+    @staticmethod
+    def mean_values(time, values) -> tuple:
+        """
+        Calculate the mean line for a numeric series.
+        """
+
+        time, data = Statistic.__arrays(time, values)
         mean = np.mean(data)
 
-        return (np.array([time[0], time[-1]]), np.array([mean, mean]))
+        return np.array([time[0], time[-1]]), np.array([mean, mean])
 
     @staticmethod
     def median(energies: list, info_parameter: str) -> tuple:
@@ -109,12 +116,20 @@ class Statistic:
         ([1, 5], [1.0, 1.0])
         """
 
-        time = concatenate_time(energies)
-        data = concatenate_parameter(energies, info_parameter)
+        energy_series = concatenate_series(energies, info_parameter)
+        return Statistic.median_values(energy_series.time,
+                                       energy_series.values)
 
+    @staticmethod
+    def median_values(time, values) -> tuple:
+        """
+        Calculate the median line for a numeric series.
+        """
+
+        time, data = Statistic.__arrays(time, values)
         median = np.median(data)
 
-        return (np.array([time[0], time[-1]]), np.array([median, median]))
+        return np.array([time[0], time[-1]]), np.array([median, median])
 
     @staticmethod
     def cumulative_average(energies: list, info_parameter: str) -> tuple:
@@ -139,11 +154,18 @@ class Statistic:
         ([1, 2, 3, 4, 5], [2.1666, 2.8571, 3.6666, 4., 4.3333])
         """
 
-        data = concatenate_parameter(energies, info_parameter)
+        energy_series = concatenate_series(energies, info_parameter)
+        return Statistic.cumulative_average_values(energy_series.time,
+                                                   energy_series.values)
 
+    @staticmethod
+    def cumulative_average_values(time, values) -> tuple:
+        """
+        Calculate the cumulative average for a numeric series.
+        """
+
+        time, data = Statistic.__arrays(time, values)
         cumulative_average = np.cumsum(data) / np.arange(1, len(data) + 1)
-
-        time = concatenate_time(energies)
 
         return time, cumulative_average
 
@@ -178,7 +200,18 @@ class Statistic:
         ([1, 2, 3, 4, 5], [1., 0.4, -0.1, -0.4, -0.4])
         """
 
-        data = concatenate_parameter(energies, info_parameter).astype(float)
+        energy_series = concatenate_series(energies, info_parameter)
+        return Statistic.auto_correlation_values(energy_series.time,
+                                                 energy_series.values)
+
+    @staticmethod
+    def auto_correlation_values(time, values) -> tuple:
+        """
+        Calculate the normalized autocorrelation for a numeric series.
+        """
+
+        time, data = Statistic.__arrays(time, values)
+        data = data.astype(float)
 
         centered_data = data - np.mean(data)
         zero_lag_correlation = np.dot(centered_data, centered_data)
@@ -191,8 +224,6 @@ class Statistic:
                 np.correlate(centered_data, centered_data,
                              mode="full")[len(data) - 1:] /
                 zero_lag_correlation)
-
-        time = concatenate_time(energies)
 
         return time, auto_correlation
 
@@ -227,7 +258,18 @@ class Statistic:
         ([1.5, 2.5, 3.5, 4.5], [10.5, 11.5, 12.5, 13.5])
         """
 
-        data = concatenate_parameter(energies, info_parameter)
+        energy_series = concatenate_series(energies, info_parameter)
+        return Statistic.running_average_values(energy_series.time,
+                                                energy_series.values,
+                                                window_size)
+
+    @staticmethod
+    def running_average_values(time, values, window_size) -> tuple:
+        """
+        Calculate the centered running average for a numeric series.
+        """
+
+        time, data = Statistic.__arrays(time, values)
 
         if window_size < 1:
             raise ValueError("Window size must be positive")
@@ -241,11 +283,17 @@ class Statistic:
             for i in range(len(data) - window_size + 1)
         ])
 
-        # Centered to the middle of the window
-        time = concatenate_time(energies)
         time = np.array([
             np.mean(time[i:i + window_size])
             for i in range(len(data) - window_size + 1)
         ])
 
         return time, running_average
+
+    @staticmethod
+    def __arrays(time, values) -> tuple:
+        """
+        Convert inputs to arrays without tying statistics to energy objects.
+        """
+
+        return np.asarray(time), np.asarray(values)

--- a/tests/statistics/test_statistic.py
+++ b/tests/statistics/test_statistic.py
@@ -14,6 +14,11 @@ class TestStatistic:
             Statistic()
 
     def test_mean(self):
+        time, mean = Statistic.mean_values([1, 2, 3, 4, 5],
+                                           [1, 2, 3, 4, 5])
+        assert np.all(time == [1, 5])
+        assert np.all(mean == [3, 3])
+
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
         time, mean = Statistic.mean(energies, "SIMULATION-TIME")
         assert np.all(time == [1, 5])
@@ -25,6 +30,11 @@ class TestStatistic:
         assert np.all(mean == [8, 8])
 
     def test_median(self):
+        time, median = Statistic.median_values([1, 2, 3, 4, 5],
+                                               [1, 2, 3, 4, 5])
+        assert np.all(time == [1, 5])
+        assert np.all(median == [3, 3])
+
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
         time, median = Statistic.median(energies, "SIMULATION-TIME")
         assert np.all(time == [1, 5])
@@ -36,6 +46,11 @@ class TestStatistic:
         assert np.all(median == [8, 8])
 
     def test_cumulative_average(self):
+        time, cumulative_average = Statistic.cumulative_average_values(
+            [1, 2, 3, 4, 5], [1, 2, 3, 4, 5])
+        assert np.all(time == [1, 2, 3, 4, 5])
+        assert np.all(cumulative_average == [1, 1.5, 2, 2.5, 3])
+
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
         time, cumulative_average = Statistic.cumulative_average(
             energies, "SIMULATION-TIME")
@@ -60,6 +75,11 @@ class TestStatistic:
         assert np.all(old_average == new_average)
 
     def test_auto_correlation(self):
+        time, auto_correlation = Statistic.auto_correlation_values(
+            [1, 2, 3, 4, 5], [1, 2, 3, 4, 5])
+        assert np.all(time == [1, 2, 3, 4, 5])
+        assert np.allclose(auto_correlation, [1, 0.4, -0.1, -0.4, -0.4])
+
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
         time, auto_correlation = Statistic.auto_correlation(
             energies, "SIMULATION-TIME")
@@ -73,6 +93,12 @@ class TestStatistic:
         assert np.allclose(auto_correlation, [1, 0.4, -0.1, -0.4, -0.4])
 
     def test_auto_correlation_constant_data(self):
+        time, auto_correlation = Statistic.auto_correlation_values(
+            [1, 2, 3, 4, 5], [2, 2, 2, 2, 2])
+
+        assert np.all(time == [1, 2, 3, 4, 5])
+        assert np.all(auto_correlation == [1, 0, 0, 0, 0])
+
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
 
         time, auto_correlation = Statistic.auto_correlation(
@@ -82,6 +108,11 @@ class TestStatistic:
         assert np.all(auto_correlation == [1, 0, 0, 0, 0])
 
     def test_running_average(self):
+        time, running_average = Statistic.running_average_values(
+            [1, 2, 3, 4, 5], [1, 2, 3, 4, 5], 2)
+        assert np.all(time == [1.5, 2.5, 3.5, 4.5])
+        assert np.all(running_average == [1.5, 2.5, 3.5, 4.5])
+
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
         time, running_average = Statistic.running_average(
             energies, "SIMULATION-TIME", 2)
@@ -98,6 +129,15 @@ class TestStatistic:
             energies2, "SIMULATION-TIME", 1)
         assert np.all(time == [6, 7, 8, 9, 10])
         assert np.all(running_average == [6, 7, 8, 9, 10])
+
+        with pytest.raises(ValueError):
+            Statistic.running_average_values([1, 2], [1, 2], 3)
+
+        with pytest.raises(ValueError):
+            Statistic.running_average_values([1, 2], [1, 2], 0)
+
+        with pytest.raises(ValueError):
+            Statistic.running_average_values([1, 2], [1, 2], -1)
 
         with pytest.raises(ValueError):
             Statistic.running_average(energies2, "SIMULATION-TIME", 6)

--- a/tests/test_energy_access.py
+++ b/tests/test_energy_access.py
@@ -5,6 +5,7 @@ from PQAnalysis.traj import MDEngineFormat
 
 from PQEnalyzer.energy_access import (
     concatenate_parameter,
+    concatenate_series,
     concatenate_time,
     parameter_unit,
     parameter_values,
@@ -64,3 +65,9 @@ def test_concatenate_helpers_join_series_from_multiple_energy_files():
         concatenate_parameter(energies, "SIMULATION-TIME"),
         np.arange(1, 11),
     )
+
+    energy_series = concatenate_series(energies, "SIMULATION-TIME")
+    np.testing.assert_array_equal(energy_series.time, np.arange(1, 11))
+    np.testing.assert_array_equal(energy_series.values, np.arange(1, 11))
+    assert energy_series.label == "SIMULATION-TIME"
+    assert energy_series.unit == "ps"


### PR DESCRIPTION
## Summary
- add a concatenated energy-series helper for multi-file parameter data
- add numeric statistics methods that operate on time/value arrays
- keep existing energy-based statistics methods as compatibility wrappers

## Verification
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing
- python -m pytest
- python -m build