### PR TITLE
Refactor Reader orchestration

### DIFF
--- a/PQEnalyzer/readers/reader.py
+++ b/PQEnalyzer/readers/reader.py
@@ -1,6 +1,5 @@
 """
-A module for reading energy files. The Reader class reads energy files using the
-EnergyFileReader class from the PQAnalysis.io module.
+Reader orchestration for PQAnalysis energy files.
 """
 
 from PQAnalysis.io import EnergyFileReader
@@ -8,34 +7,37 @@ from PQAnalysis.io import EnergyFileReader
 
 class Reader:
     """
-    A class for reading energy files. Using the EnergyFileReader class from
-    the PQAnalysis.io module.
+    Read energy files with PQAnalysis and validate plot compatibility.
+
+    PQAnalysis owns the energy-file parsing. This wrapper keeps the
+    PQEnalyzer-specific behavior around multi-file reads: every selected file
+    must expose the same parameter mapping and units before plotting.
 
     ...
 
     Attributes
     ----------
     energies : list
-        A list of EnergyFileReader objects.
+        A list of parsed PQAnalysis Energy objects.
     filenames : list
-        A list of filenames.
+        The energy filenames to read.
     md_format : MDEngineFormat
         The molecular dynamics engine format.
 
     Methods
     -------
     read()
-        Read energy files and return a list of EnergyFileReader objects.
+        Read all configured energy files.
+    read_last()
+        Refresh only the last configured energy file.
 
 
     Examples
     --------
     >>> reader = Reader(["md-01.en", "md-02.en"], MDEngineFormat.PQ)
     >>> reader.read()
-    >>> reader.energies[0].info
-    ['SIMULATION-TIME', 'ENERGY', 'KINETIC', 'POTENTIAL', 'TEMPERATURE', 'PRESSURE']
-    >>> reader.energies[0].data['ENERGY']
-    [0.0, -0.5, -1.0, -1.5, -2.0]
+    >>> reader.energies[0].temperature
+    array([...])
     """
 
     def __init__(self, filenames, md_format):
@@ -55,56 +57,65 @@ class Reader:
         """
 
         self.energies = []
-        self.filenames = filenames
+        self.filenames = list(filenames)
         self.md_format = md_format
         self.read()
 
     def read(self):
         """
-        Read energy files and return a list of EnergyFileReader objects.
+        Read all energy files through PQAnalysis and validate compatibility.
 
         Returns
         -------
         None
+        """
+
+        self.__validate_filenames()
+
+        energies = [
+            self.__read_energy_file(filename) for filename in self.filenames
+        ]
+
+        self.__validate_energy_compatibility(energies)
+
+        self.energies = energies
+
+    def read_last(self):
+        """
+        Refresh the last energy file while preserving compatibility checks.
+
+        Returns
+        -------
+        None
+        """
+
+        self.__validate_filenames()
+
+        refreshed_energy = self.__read_energy_file(self.filenames[-1])
+        refreshed_energies = [*self.energies]
+        refreshed_energies[-1] = refreshed_energy
+
+        self.__validate_energy_compatibility(refreshed_energies)
+        self.energies[-1] = refreshed_energy
+
+    def __read_energy_file(self, filename):
+        """
+        Read one energy file with PQAnalysis.
+        """
+
+        return EnergyFileReader(filename,
+                                engine_format=self.md_format).read()
+
+    def __validate_filenames(self):
+        """
+        Reject empty input before handing control to PQAnalysis.
         """
 
         if len(self.filenames) == 0:
             raise ValueError(
                 "The list of filenames is empty. Provide a list of filenames.")
 
-        energy_files = []
-        for filename in self.filenames:
-            energy_files.append(
-                EnergyFileReader(filename, engine_format=self.md_format))
-
-        read_energy_files = []
-        for energy_file in energy_files:
-            read_energy_file = energy_file.read()
-            read_energy_files.append(read_energy_file)
-
-        self.__validate_info_compatibility(read_energy_files)
-
-        self.energies = read_energy_files
-
-    def read_last(self):
-        """
-        Read the last energy file and adds it to the list of EnergyFileReader objects.
-
-        Returns
-        -------
-        None
-        """
-        energy_file = EnergyFileReader(self.filenames[-1],
-                                       engine_format=self.md_format)
-        refreshed_energy = energy_file.read()
-        refreshed_energies = [*self.energies]
-        refreshed_energies[-1] = refreshed_energy
-
-        self.__validate_info_compatibility(refreshed_energies)
-
-        self.energies[-1] = refreshed_energy
-
-    def __validate_info_compatibility(self, read_energy_files):
+    def __validate_energy_compatibility(self, energies):
         """
         Check if all energy files expose the same parameters and units.
 
@@ -113,16 +124,16 @@ class Reader:
         None
         """
 
-        reference_info = read_energy_files[0].info
-        reference_units = read_energy_files[0].units
+        reference_info = energies[0].info
+        reference_units = energies[0].units
 
-        for index, energy_file in enumerate(read_energy_files[1:], start=1):
-            if energy_file.info != reference_info:
+        for index, energy in enumerate(energies[1:], start=1):
+            if energy.info != reference_info:
                 raise ValueError(
                     "The energy files do not have the same info parameters: "
                     f"{self.filenames[0]} and {self.filenames[index]}.")
 
-            if energy_file.units != reference_units:
+            if energy.units != reference_units:
                 raise ValueError(
                     "The energy files do not have the same units: "
                     f"{self.filenames[0]} and {self.filenames[index]}.")


### PR DESCRIPTION
## Summary
- clarify Reader as PQAnalysis parsing orchestration plus PQEnalyzer compatibility validation
- extract single-file reading and filename validation helpers
- update stale Reader docs/examples away from raw parsed data internals

## Verification
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing
- python -m pytest
- python -m build