### PR TITLE
Refactor GUI layout builders

### DIFF
--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -3,17 +3,21 @@ This module contains the App class that is used to create the main application
 window for the PQEnalyzer application.
 """
 
-import os
 import signal
-import tkinter
 
 import customtkinter as ctk
-from PIL import Image, ImageTk
 import matplotlib.pyplot as plt
 
-from .. import __base__
 from .._logging import get_logger
 from ..plots import PlotTime, PlotHistogram
+from .app_layout import (
+    build_parameter_selector,
+    build_plot_controls,
+    build_settings_controls,
+    build_sidebar,
+    configure_default_theme,
+    configure_window,
+)
 
 
 logger = get_logger(__name__)
@@ -42,15 +46,8 @@ class App(ctk.CTk):
         Constructs all the necessary attributes for the App object.
         """
         super().__init__()
-        self.__default_theme()
-        self.title("PQEnalyzer - MolarVerse")
-
-        # load icon photo
-        img = Image.open(os.path.join(__base__, "icons", "icon.png"))
-        self.iconphoto(False, ImageTk.PhotoImage(img))
-
-        # set the window size
-        self.resizable(False, False)
+        configure_default_theme()
+        configure_window(self)
 
         # set reader object and info parameters
         self.reader = reader
@@ -76,261 +73,11 @@ class App(ctk.CTk):
         """
         Build the main window.
         """
-        self.__build_sidebar()
-        self.__build_button_menu()
-        self.__build_info_option_menu()
-        self.__build_settings_menu()
-
-    def __default_theme(self):
-        """
-        Sets the default theme for the application.
-        """
-        ctk.set_appearance_mode("System")
-        ctk.set_default_color_theme("blue")
-
-    def __build_sidebar(self):
-        """
-        Build the main window.
-
-        Returns
-        -------
-        None
-        """
-        # sidebar frame
-        self.sidebar_frame = ctk.CTkFrame(self, width=140, corner_radius=0)
-        self.sidebar_frame.grid(row=0, column=0, rowspan=4, sticky="nsew")
-        self.sidebar_frame.grid_rowconfigure(4, weight=1)
-        self.sidebar_frame.grid_columnconfigure(0, weight=1)
-
-        # logo
-        self.logo = ctk.CTkImage(
-            Image.open(os.path.join(__base__, "icons", "icon.png")),
-            size=(100, 100),
-        )
-        self.sidebar_image_label = ctk.CTkLabel(self.sidebar_frame,
-                                                image=self.logo,
-                                                text="")
-        self.sidebar_image_label.grid(row=0, column=0, pady=10, padx=10)
-        self.logo_label = ctk.CTkLabel(
-            self.sidebar_frame,
-            text="PQEnalyzer",
-            font=ctk.CTkFont(size=20, weight="bold"),
-        )
-        self.logo_label.grid(row=1, column=0, padx=10, pady=10)
-
-        # change appearance mode
-        self.appearance_mode_label = ctk.CTkLabel(self.sidebar_frame,
-                                                  text="Appearance Mode:",
-                                                  anchor="w")
-        self.appearance_mode_label.grid(row=5, column=0, padx=20, pady=(10, 0))
-        self.appearance_mode_optionemenu = ctk.CTkOptionMenu(
-            self.sidebar_frame,
-            values=["System", "Light", "Dark"],
-            command=self.__change_appearance_mode_event,
-        )
-        self.appearance_mode_optionemenu.grid(row=6,
-                                              column=0,
-                                              padx=20,
-                                              pady=(10, 10))
-        self.appearance_mode_optionemenu.set(
-            "System")  # set the default appearance mode to System
-
-    def __build_button_menu(self):
-        """
-        Build the main window.
-
-        Returns
-        -------
-        None
-        """
-        self.plot_frame = ctk.CTkFrame(self, width=200)
-        self.plot_frame.grid(row=2,
-                             column=1,
-                             sticky="nsew",
-                             padx=(20, 20),
-                             pady=(10, 10))
-        self.plot_frame.grid_rowconfigure(4, weight=1)
-        self.plot_frame.grid_columnconfigure(2, weight=1)
-
-        self.follow = tkinter.BooleanVar()
-        self.interval = None  # Initially None
-        self.check_follow = ctk.CTkCheckBox(
-            master=self.plot_frame,
-            border_width=2,
-            text="Follow",
-            variable=self.follow,
-            command=lambda: self.toggle_entry_state(
-                self.check_follow, self.interval, default="1.0"))
-        self.check_follow.grid(row=0,
-                               column=1,
-                               padx=(10, 10),
-                               pady=(10, 10),
-                               sticky="nsew")
-
-        self.plot_main_data = tkinter.BooleanVar()
-        self.check_nodata = ctk.CTkCheckBox(
-            master=self.plot_frame,
-            border_width=2,
-            text="No Data",
-            variable=self.plot_main_data,
-        )
-        self.check_nodata.grid(row=0,
-                               column=0,
-                               padx=(10, 10),
-                               pady=(10, 10),
-                               sticky="nsew")
-
-        self.interval = ctk.CTkEntry(
-            self.plot_frame,
-            width=10,
-            validate="key",
-            validatecommand=(self.register(self.validate_number), "%P"),
-        )
-        self.interval.grid(row=1, column=1, padx=10, pady=5, sticky="we")
-        self.interval.configure(state="disabled")  # Initially disabled
-
-        self.interval_label = ctk.CTkLabel(self.plot_frame,
-                                           text="Interval (s):",
-                                           anchor="w")
-        self.interval_label.grid(row=1, column=0, padx=10, pady=5, sticky="w")
-
-        self.button_plot = ctk.CTkButton(
-            master=self.plot_frame,
-            border_width=2,
-            text="Plot",
-            command=lambda: self.__plot_button_event(0),
-        )
-
-        self.button_plot.grid(row=2,
-                              column=0,
-                              columnspan=2,
-                              padx=(10, 10),
-                              pady=(10, 10),
-                              sticky="nsew")
-
-        self.button_hist = ctk.CTkButton(
-            master=self.plot_frame,
-            border_width=2,
-            text="Histogram",
-            command=lambda: self.__plot_button_event(1),
-        )
-        self.button_hist.grid(row=3,
-                              column=0,
-                              columnspan=2,
-                              padx=(10, 10),
-                              pady=(10, 10),
-                              sticky="nsew")
-
-        self.button_refresh = ctk.CTkButton(  # refresh button
-            master=self.plot_frame,
-            border_width=2,
-            text="Refresh",
-            command=self.__refresh_plots,
-        )
-        self.button_refresh.grid(row=4,
-                                 column=0,
-                                 columnspan=2,
-                                 padx=(10, 10),
-                                 pady=(10, 10),
-                                 sticky="nsew")
-
-    def __build_info_option_menu(self):
-        """
-        Build the info selection window.
-
-        Returns
-        -------
-        None
-        """
-        self.info_frame = ctk.CTkFrame(self, width=200)
-        self.info_frame.grid(row=0,
-                             column=1,
-                             sticky="nsew",
-                             padx=(20, 20),
-                             pady=(10, 10))
-        self.info_frame.grid_rowconfigure(2, weight=1)
-        self.info_frame.grid_columnconfigure(1, weight=1)
-
-        self.info_label = ctk.CTkLabel(self.info_frame,
-                                       text="Parameter:",
-                                       font=ctk.CTkFont(size=15,
-                                                        weight="bold"))
-        self.info_label.grid(row=0, column=1, padx=20, pady=10, sticky="w")
-        self.info_optionmenu = ctk.CTkOptionMenu(
-            self.info_frame,
-            values=self.info,
-            command=self.__change_info_event,
-            width=150,
-            anchor="c",
-        )
-        self.info_optionmenu.grid(row=1, column=1, padx=20, pady=10)
-        self.__change_info_event(
-            self.info[0])  # set the default info parameter to the first one
-
-    def __build_settings_menu(self):
-        """
-        Build the settings window.
-
-        Returns
-        -------
-        None
-        """
-        self.settings_frame = ctk.CTkFrame(self, width=200)
-        self.settings_frame.grid(row=1,
-                                 column=1,
-                                 sticky="nsew",
-                                 padx=(20, 20),
-                                 pady=(10, 10))
-        self.settings_frame.grid_rowconfigure(8, weight=1)
-        self.settings_frame.grid_columnconfigure(0, weight=1)
-
-        self.settings_label = ctk.CTkLabel(
-            self.settings_frame,
-            text="Statistics:",
-            font=ctk.CTkFont(size=15, weight="bold"),
-        )
-        self.settings_label.grid(row=0, column=0, padx=10, pady=5, sticky="w")
-        self.mean = ctk.CTkCheckBox(self.settings_frame, text="Mean")
-        self.mean.grid(row=1, column=0, padx=10, pady=5, sticky="w")
-        self.median = ctk.CTkCheckBox(self.settings_frame, text="Median")
-        self.median.grid(row=2, column=0, padx=10, pady=5, sticky="w")
-        self.cummulative_average = ctk.CTkCheckBox(self.settings_frame,
-                                                   text="Cumulative Average")
-        self.cummulative_average.grid(row=3,
-                                      column=0,
-                                      padx=10,
-                                      pady=5,
-                                      sticky="w")
-        self.auto_correlation = ctk.CTkCheckBox(self.settings_frame,
-                                                text="Auto Correlation")
-        self.auto_correlation.grid(row=4,
-                                   column=0,
-                                   padx=10,
-                                   pady=5,
-                                   sticky="w")
-
-        self.window_size = None  # Initially None
-        self.running_average = ctk.CTkCheckBox(
-            self.settings_frame,
-            text="Running Average",
-            command=lambda: self.toggle_entry_state(
-                self.running_average, self.window_size, default="10"))
-        self.running_average.grid(row=5, column=0, padx=10, pady=5, sticky="w")
-        self.running_average_window_size_label = ctk.CTkLabel(
-            self.settings_frame, text="Window Size:", anchor="w")
-        self.running_average_window_size_label.grid(row=6,
-                                                    column=0,
-                                                    padx=10,
-                                                    pady=5,
-                                                    sticky="w")
-        self.window_size = ctk.CTkEntry(
-            self.settings_frame,
-            width=10,
-            validate="key",
-            validatecommand=(self.register(self.validate_number), "%P"),
-        )
-        self.window_size.grid(row=7, column=0, padx=10, pady=5, sticky="we")
-        self.window_size.configure(state="disabled")  # Initially disabled
+        build_sidebar(self, self.__change_appearance_mode_event)
+        build_plot_controls(self, self.__plot_button_event,
+                            self.__refresh_plots)
+        build_parameter_selector(self, self.__change_info_event)
+        build_settings_controls(self)
 
     def validate_number(self, value):
         """

--- a/PQEnalyzer/apps/app_layout.py
+++ b/PQEnalyzer/apps/app_layout.py
@@ -1,0 +1,263 @@
+"""
+Layout builders for the PQEnalyzer GUI.
+"""
+
+import os
+import tkinter
+
+import customtkinter as ctk
+from PIL import Image, ImageTk
+
+from .. import __base__
+
+
+def configure_default_theme():
+    """
+    Configure the default CustomTkinter theme.
+    """
+
+    ctk.set_appearance_mode("System")
+    ctk.set_default_color_theme("blue")
+
+
+def configure_window(app):
+    """
+    Configure top-level window settings.
+    """
+
+    app.title("PQEnalyzer - MolarVerse")
+
+    image = Image.open(os.path.join(__base__, "icons", "icon.png"))
+    app.iconphoto(False, ImageTk.PhotoImage(image))
+
+    app.resizable(False, False)
+
+
+def build_sidebar(app, change_appearance_mode_callback):
+    """
+    Build the sidebar and theme selector.
+    """
+
+    app.sidebar_frame = ctk.CTkFrame(app, width=140, corner_radius=0)
+    app.sidebar_frame.grid(row=0, column=0, rowspan=4, sticky="nsew")
+    app.sidebar_frame.grid_rowconfigure(4, weight=1)
+    app.sidebar_frame.grid_columnconfigure(0, weight=1)
+
+    app.logo = ctk.CTkImage(
+        Image.open(os.path.join(__base__, "icons", "icon.png")),
+        size=(100, 100),
+    )
+    app.sidebar_image_label = ctk.CTkLabel(app.sidebar_frame,
+                                           image=app.logo,
+                                           text="")
+    app.sidebar_image_label.grid(row=0, column=0, pady=10, padx=10)
+    app.logo_label = ctk.CTkLabel(
+        app.sidebar_frame,
+        text="PQEnalyzer",
+        font=ctk.CTkFont(size=20, weight="bold"),
+    )
+    app.logo_label.grid(row=1, column=0, padx=10, pady=10)
+
+    app.appearance_mode_label = ctk.CTkLabel(app.sidebar_frame,
+                                             text="Appearance Mode:",
+                                             anchor="w")
+    app.appearance_mode_label.grid(row=5, column=0, padx=20, pady=(10, 0))
+    app.appearance_mode_optionemenu = ctk.CTkOptionMenu(
+        app.sidebar_frame,
+        values=["System", "Light", "Dark"],
+        command=change_appearance_mode_callback,
+    )
+    app.appearance_mode_optionemenu.grid(row=6,
+                                         column=0,
+                                         padx=20,
+                                         pady=(10, 10))
+    app.appearance_mode_optionemenu.set("System")
+
+
+def build_plot_controls(app, plot_button_callback, refresh_callback):
+    """
+    Build plot command controls.
+    """
+
+    app.plot_frame = ctk.CTkFrame(app, width=200)
+    app.plot_frame.grid(row=2,
+                        column=1,
+                        sticky="nsew",
+                        padx=(20, 20),
+                        pady=(10, 10))
+    app.plot_frame.grid_rowconfigure(4, weight=1)
+    app.plot_frame.grid_columnconfigure(2, weight=1)
+
+    app.follow = tkinter.BooleanVar()
+    app.interval = None
+    app.check_follow = ctk.CTkCheckBox(
+        master=app.plot_frame,
+        border_width=2,
+        text="Follow",
+        variable=app.follow,
+        command=lambda: app.toggle_entry_state(
+            app.check_follow, app.interval, default="1.0"))
+    app.check_follow.grid(row=0,
+                          column=1,
+                          padx=(10, 10),
+                          pady=(10, 10),
+                          sticky="nsew")
+
+    app.plot_main_data = tkinter.BooleanVar()
+    app.check_nodata = ctk.CTkCheckBox(
+        master=app.plot_frame,
+        border_width=2,
+        text="No Data",
+        variable=app.plot_main_data,
+    )
+    app.check_nodata.grid(row=0,
+                          column=0,
+                          padx=(10, 10),
+                          pady=(10, 10),
+                          sticky="nsew")
+
+    app.interval = ctk.CTkEntry(
+        app.plot_frame,
+        width=10,
+        validate="key",
+        validatecommand=(app.register(app.validate_number), "%P"),
+    )
+    app.interval.grid(row=1, column=1, padx=10, pady=5, sticky="we")
+    app.interval.configure(state="disabled")
+
+    app.interval_label = ctk.CTkLabel(app.plot_frame,
+                                      text="Interval (s):",
+                                      anchor="w")
+    app.interval_label.grid(row=1, column=0, padx=10, pady=5, sticky="w")
+
+    app.button_plot = ctk.CTkButton(
+        master=app.plot_frame,
+        border_width=2,
+        text="Plot",
+        command=lambda: plot_button_callback(0),
+    )
+
+    app.button_plot.grid(row=2,
+                         column=0,
+                         columnspan=2,
+                         padx=(10, 10),
+                         pady=(10, 10),
+                         sticky="nsew")
+
+    app.button_hist = ctk.CTkButton(
+        master=app.plot_frame,
+        border_width=2,
+        text="Histogram",
+        command=lambda: plot_button_callback(1),
+    )
+    app.button_hist.grid(row=3,
+                         column=0,
+                         columnspan=2,
+                         padx=(10, 10),
+                         pady=(10, 10),
+                         sticky="nsew")
+
+    app.button_refresh = ctk.CTkButton(
+        master=app.plot_frame,
+        border_width=2,
+        text="Refresh",
+        command=refresh_callback,
+    )
+    app.button_refresh.grid(row=4,
+                            column=0,
+                            columnspan=2,
+                            padx=(10, 10),
+                            pady=(10, 10),
+                            sticky="nsew")
+
+
+def build_parameter_selector(app, change_info_callback):
+    """
+    Build the parameter selection controls.
+    """
+
+    app.info_frame = ctk.CTkFrame(app, width=200)
+    app.info_frame.grid(row=0,
+                        column=1,
+                        sticky="nsew",
+                        padx=(20, 20),
+                        pady=(10, 10))
+    app.info_frame.grid_rowconfigure(2, weight=1)
+    app.info_frame.grid_columnconfigure(1, weight=1)
+
+    app.info_label = ctk.CTkLabel(app.info_frame,
+                                  text="Parameter:",
+                                  font=ctk.CTkFont(size=15, weight="bold"))
+    app.info_label.grid(row=0, column=1, padx=20, pady=10, sticky="w")
+    app.info_optionmenu = ctk.CTkOptionMenu(
+        app.info_frame,
+        values=app.info,
+        command=change_info_callback,
+        width=150,
+        anchor="c",
+    )
+    app.info_optionmenu.grid(row=1, column=1, padx=20, pady=10)
+    change_info_callback(app.info[0])
+
+
+def build_settings_controls(app):
+    """
+    Build statistics option controls.
+    """
+
+    app.settings_frame = ctk.CTkFrame(app, width=200)
+    app.settings_frame.grid(row=1,
+                            column=1,
+                            sticky="nsew",
+                            padx=(20, 20),
+                            pady=(10, 10))
+    app.settings_frame.grid_rowconfigure(8, weight=1)
+    app.settings_frame.grid_columnconfigure(0, weight=1)
+
+    app.settings_label = ctk.CTkLabel(
+        app.settings_frame,
+        text="Statistics:",
+        font=ctk.CTkFont(size=15, weight="bold"),
+    )
+    app.settings_label.grid(row=0, column=0, padx=10, pady=5, sticky="w")
+    app.mean = ctk.CTkCheckBox(app.settings_frame, text="Mean")
+    app.mean.grid(row=1, column=0, padx=10, pady=5, sticky="w")
+    app.median = ctk.CTkCheckBox(app.settings_frame, text="Median")
+    app.median.grid(row=2, column=0, padx=10, pady=5, sticky="w")
+    app.cummulative_average = ctk.CTkCheckBox(app.settings_frame,
+                                              text="Cumulative Average")
+    app.cummulative_average.grid(row=3,
+                                 column=0,
+                                 padx=10,
+                                 pady=5,
+                                 sticky="w")
+    app.auto_correlation = ctk.CTkCheckBox(app.settings_frame,
+                                           text="Auto Correlation")
+    app.auto_correlation.grid(row=4,
+                              column=0,
+                              padx=10,
+                              pady=5,
+                              sticky="w")
+
+    app.window_size = None
+    app.running_average = ctk.CTkCheckBox(
+        app.settings_frame,
+        text="Running Average",
+        command=lambda: app.toggle_entry_state(
+            app.running_average, app.window_size, default="10"))
+    app.running_average.grid(row=5, column=0, padx=10, pady=5, sticky="w")
+    app.running_average_window_size_label = ctk.CTkLabel(
+        app.settings_frame, text="Window Size:", anchor="w")
+    app.running_average_window_size_label.grid(row=6,
+                                               column=0,
+                                               padx=10,
+                                               pady=5,
+                                               sticky="w")
+    app.window_size = ctk.CTkEntry(
+        app.settings_frame,
+        width=10,
+        validate="key",
+        validatecommand=(app.register(app.validate_number), "%P"),
+    )
+    app.window_size.grid(row=7, column=0, padx=10, pady=5, sticky="we")
+    app.window_size.configure(state="disabled")

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -1,8 +1,11 @@
+from types import SimpleNamespace
+
 import customtkinter as ctk
 import matplotlib.pyplot as plt
 import pytest
 
 from PQEnalyzer.apps import app as app_module
+from PQEnalyzer.apps import app_layout
 
 
 class FakeFlag:
@@ -46,6 +49,28 @@ class DummyPlot:
 
     def simple(self, info_parameter):
         self.calls.append(("simple", info_parameter))
+
+
+class FakeWidget:
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.grid_calls = []
+        self.configured_rows = []
+        self.configured_columns = []
+
+    def grid(self, *args, **kwargs):
+        self.grid_calls.append((args, kwargs))
+
+    def grid_rowconfigure(self, *args, **kwargs):
+        self.configured_rows.append((args, kwargs))
+
+    def grid_columnconfigure(self, *args, **kwargs):
+        self.configured_columns.append((args, kwargs))
+
+    def set(self, value):
+        self.value = value
 
 
 @pytest.fixture(autouse=True)
@@ -135,6 +160,52 @@ def test_destroy_closes_plots_and_tk_window(monkeypatch):
     app_module.App.destroy(object.__new__(app_module.App))
 
     assert calls == [("close", "all"), ("quit", None), ("destroy", None)]
+
+
+def test_build_delegates_to_layout_builders(monkeypatch):
+    app = object.__new__(app_module.App)
+    calls = []
+
+    monkeypatch.setattr(app_module, "build_sidebar",
+                        lambda app, callback: calls.append(
+                            ("sidebar", app, callback)))
+    monkeypatch.setattr(app_module, "build_plot_controls",
+                        lambda app, plot_callback, refresh_callback:
+                        calls.append(("plot", app, plot_callback,
+                                      refresh_callback)))
+    monkeypatch.setattr(app_module, "build_parameter_selector",
+                        lambda app, callback: calls.append(
+                            ("parameter", app, callback)))
+    monkeypatch.setattr(app_module, "build_settings_controls",
+                        lambda app: calls.append(("settings", app)))
+
+    app_module.App.build(app)
+
+    assert [call[0] for call in calls] == [
+        "sidebar",
+        "plot",
+        "parameter",
+        "settings",
+    ]
+    assert all(call[1] is app for call in calls)
+    assert all(call[-1] is not None for call in calls[:3])
+
+
+def test_parameter_selector_builder_sets_initial_selection(monkeypatch):
+    app = SimpleNamespace(info=["TEMPERATURE", "PRESSURE"])
+    selected = []
+
+    monkeypatch.setattr(app_layout.ctk, "CTkFrame", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkLabel", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkOptionMenu", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkFont",
+                        lambda *args, **kwargs: ("font", args, kwargs))
+
+    app_layout.build_parameter_selector(app, selected.append)
+
+    assert selected == ["TEMPERATURE"]
+    assert app.info_optionmenu.kwargs["values"] == ["TEMPERATURE", "PRESSURE"]
+    assert app.info_optionmenu.kwargs["command"] == selected.append
 
 
 def test_plot_button_rejects_invalid_follow_interval(monkeypatch, caplog):


### PR DESCRIPTION
## Summary
- move GUI layout construction into focused app layout builders
- keep App responsible for state, callbacks, plotting coordination, and lifecycle
- add tests for App build delegation and extracted parameter selector initialization

## Verification
- python -m pytest tests/apps/test_app.py tests/e2e/test_cli_modes.py -q
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing
- python -m pytest
- python -m build