### PR TITLE
Sync plot theme with GUI appearance

### DIFF
--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 
 from .._logging import get_logger
 from ..plots import PlotTime, PlotHistogram
+from ..plots.theme import apply_matplotlib_theme, resolve_appearance_mode
 from .app_layout import (
     configure_default_theme,
     configure_window,
@@ -47,6 +48,8 @@ class App(ctk.CTk):
         """
         super().__init__()
         configure_default_theme()
+        self.appearance_mode = resolve_appearance_mode("System")
+        apply_matplotlib_theme(self.appearance_mode)
         configure_window(self)
 
         self.reader = reader
@@ -127,6 +130,9 @@ class App(ctk.CTk):
         """
 
         ctk.set_appearance_mode(new_appearance_mode)
+        self.appearance_mode = resolve_appearance_mode(new_appearance_mode)
+        apply_matplotlib_theme(self.appearance_mode)
+        self.__redraw_plots()
 
     def __change_info_event(self, new_info: str):
         """
@@ -146,6 +152,18 @@ class App(ctk.CTk):
                 continue
 
             plot.refresh()
+
+    def __redraw_plots(self):
+        """
+        Redraw open plots after visual-only GUI setting changes.
+        """
+        for plot in list(self.list_of_plots):
+
+            if plot.figure.number not in plt.get_fignums():
+                self.list_of_plots.remove(plot)
+                continue
+
+            plot.redraw()
 
     def __plot_button_event(self, event):
         """

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -6,6 +6,8 @@ from abc import abstractmethod, ABCMeta
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
+from .theme import apply_figure_theme, apply_matplotlib_theme
+
 
 class Plot(metaclass=ABCMeta):
     """
@@ -51,8 +53,10 @@ class Plot(metaclass=ABCMeta):
         self.get_app_parameters()
 
         # create the plot
+        apply_matplotlib_theme(getattr(self.app, "appearance_mode", None))
         self.figure = plt.figure()
         self.ax = self.figure.add_subplot(111)
+        self.apply_theme()
 
         # set the signal handler
         signal.signal(
@@ -144,6 +148,7 @@ class Plot(metaclass=ABCMeta):
         def update(frame):
             self.reader.read_last()
             self.ax.clear()
+            self.apply_theme()
             self.plot_data()
             return []
 
@@ -169,17 +174,27 @@ class Plot(metaclass=ABCMeta):
         # Reads the last data
         self.reader.read_last()
 
+        self.redraw()
+
+        # Show the plot
+        plt.show()
+
+    def redraw(self) -> None:
+        """
+        Redraw an existing plot without reading new file contents.
+        """
+
         # Get the new parameters
         self.get_app_parameters()
 
         # Clear the plot
         self.ax.clear()
+        self.apply_theme()
 
         # Plot the data
         self.plot_data()
 
-        # Show the plot
-        plt.show()
+        self.figure.canvas.draw_idle()
 
     def plot_data(self) -> None:
         """
@@ -196,8 +211,20 @@ class Plot(metaclass=ABCMeta):
         self.statistics(self.info_parameter)
 
         self.labels(self.info_parameter)
+        self.apply_theme()
 
         return None
+
+    def apply_theme(self) -> None:
+        """
+        Apply the active application appearance mode to this plot.
+        """
+
+        apply_figure_theme(
+            self.figure,
+            self.ax,
+            getattr(self.app, "appearance_mode", None),
+        )
 
     @abstractmethod
     def main_data(self, info_parameter: str):

--- a/PQEnalyzer/plots/theme.py
+++ b/PQEnalyzer/plots/theme.py
@@ -1,0 +1,126 @@
+"""
+Matplotlib theme helpers aligned with CustomTkinter appearance modes.
+"""
+
+import customtkinter as ctk
+import matplotlib
+from cycler import cycler
+
+
+LIGHT_PALETTE = {
+    "figure.facecolor": "#f8fafc",
+    "axes.facecolor": "#ffffff",
+    "axes.edgecolor": "#64748b",
+    "axes.labelcolor": "#0f172a",
+    "text.color": "#0f172a",
+    "tick.color": "#334155",
+    "grid.color": "#cbd5e1",
+    "legend.facecolor": "#ffffff",
+    "legend.edgecolor": "#cbd5e1",
+    "annotation.facecolor": "#f1f5f9",
+    "annotation.edgecolor": "#cbd5e1",
+    "colors": ["#2563eb", "#e11d48", "#059669", "#7c3aed", "#d97706"],
+}
+
+DARK_PALETTE = {
+    "figure.facecolor": "#111827",
+    "axes.facecolor": "#0f172a",
+    "axes.edgecolor": "#94a3b8",
+    "axes.labelcolor": "#e5e7eb",
+    "text.color": "#e5e7eb",
+    "tick.color": "#cbd5e1",
+    "grid.color": "#334155",
+    "legend.facecolor": "#111827",
+    "legend.edgecolor": "#475569",
+    "annotation.facecolor": "#1e293b",
+    "annotation.edgecolor": "#475569",
+    "colors": ["#60a5fa", "#fb7185", "#34d399", "#c084fc", "#fbbf24"],
+}
+
+
+def resolve_appearance_mode(appearance_mode=None):
+    """
+    Resolve ``System`` and unset modes to the active CustomTkinter mode.
+    """
+
+    if appearance_mode in {None, "System"}:
+        return ctk.get_appearance_mode()
+
+    return appearance_mode
+
+
+def palette_for_appearance_mode(appearance_mode=None):
+    """
+    Return the palette matching a CustomTkinter appearance mode.
+    """
+
+    resolved_mode = resolve_appearance_mode(appearance_mode)
+    if resolved_mode == "Dark":
+        return DARK_PALETTE
+
+    return LIGHT_PALETTE
+
+
+def apply_matplotlib_theme(appearance_mode=None):
+    """
+    Apply a CustomTkinter-aligned palette to matplotlib defaults.
+    """
+
+    palette = palette_for_appearance_mode(appearance_mode)
+
+    matplotlib.rcParams.update({
+        "figure.facecolor": palette["figure.facecolor"],
+        "axes.facecolor": palette["axes.facecolor"],
+        "axes.edgecolor": palette["axes.edgecolor"],
+        "axes.labelcolor": palette["axes.labelcolor"],
+        "axes.grid": True,
+        "axes.prop_cycle": cycler(color=palette["colors"]),
+        "text.color": palette["text.color"],
+        "xtick.color": palette["tick.color"],
+        "ytick.color": palette["tick.color"],
+        "grid.color": palette["grid.color"],
+        "grid.alpha": 0.35,
+        "legend.facecolor": palette["legend.facecolor"],
+        "legend.edgecolor": palette["legend.edgecolor"],
+        "legend.framealpha": 0.95,
+        "savefig.facecolor": palette["figure.facecolor"],
+    })
+
+    return palette
+
+
+def apply_figure_theme(figure, axes, appearance_mode=None):
+    """
+    Apply the active palette to an already-created figure and axes.
+    """
+
+    palette = apply_matplotlib_theme(appearance_mode)
+
+    figure.patch.set_facecolor(palette["figure.facecolor"])
+    axes.set_facecolor(palette["axes.facecolor"])
+    axes.grid(True, color=palette["grid.color"], alpha=0.35)
+    axes.tick_params(colors=palette["tick.color"])
+    axes.xaxis.label.set_color(palette["axes.labelcolor"])
+    axes.yaxis.label.set_color(palette["axes.labelcolor"])
+    axes.title.set_color(palette["text.color"])
+
+    for spine in axes.spines.values():
+        spine.set_color(palette["axes.edgecolor"])
+
+    legend = axes.get_legend()
+    if legend is not None:
+        legend.get_frame().set_facecolor(palette["legend.facecolor"])
+        legend.get_frame().set_edgecolor(palette["legend.edgecolor"])
+        legend.get_frame().set_alpha(0.95)
+        for text in legend.get_texts():
+            text.set_color(palette["text.color"])
+
+    for text in axes.texts:
+        text.set_color(palette["text.color"])
+        bbox = text.get_bbox_patch()
+        if bbox is not None:
+            bbox.set_facecolor(palette["annotation.facecolor"])
+            bbox.set_edgecolor(palette["annotation.edgecolor"])
+            bbox.set_alpha(0.85)
+
+    return palette

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -283,3 +283,39 @@ def test_plot_button_runs_simple_histogram(monkeypatch):
 def test_plot_button_rejects_unknown_event():
     with pytest.raises(ValueError, match="Unknown plot event"):
         app_module.App._App__plot_button_event(make_app(), 3)
+
+
+def test_change_appearance_mode_updates_matplotlib_and_open_plots(monkeypatch):
+    app = make_app()
+    calls = []
+
+    class FakeFigure:
+
+        def __init__(self, number):
+            self.number = number
+
+    class FakePlot:
+
+        def __init__(self, number):
+            self.figure = FakeFigure(number)
+
+        def redraw(self):
+            calls.append(("redraw", self.figure.number))
+
+    open_plot = FakePlot(1)
+    closed_plot = FakePlot(2)
+    app.list_of_plots = [open_plot, closed_plot]
+
+    monkeypatch.setattr(app_module.ctk, "set_appearance_mode",
+                        lambda mode: calls.append(("ctk", mode)))
+    monkeypatch.setattr(app_module, "resolve_appearance_mode",
+                        lambda mode: "Dark")
+    monkeypatch.setattr(app_module, "apply_matplotlib_theme",
+                        lambda mode: calls.append(("mpl", mode)))
+    monkeypatch.setattr(app_module.plt, "get_fignums", lambda: [1])
+
+    app_module.App._App__change_appearance_mode_event(app, "Dark")
+
+    assert app.appearance_mode == "Dark"
+    assert app.list_of_plots == [open_plot]
+    assert calls == [("ctk", "Dark"), ("mpl", "Dark"), ("redraw", 1)]

--- a/tests/plots/test_theme.py
+++ b/tests/plots/test_theme.py
@@ -1,0 +1,49 @@
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from matplotlib.colors import to_rgba
+
+from PQEnalyzer.plots import theme
+
+
+def test_system_appearance_mode_resolves_to_current_customtkinter_mode(
+        monkeypatch):
+    monkeypatch.setattr(theme.ctk, "get_appearance_mode", lambda: "Dark")
+
+    assert theme.resolve_appearance_mode("System") == "Dark"
+
+
+def test_apply_matplotlib_theme_sets_dark_defaults():
+    with mpl.rc_context():
+        palette = theme.apply_matplotlib_theme("Dark")
+
+        assert mpl.rcParams["figure.facecolor"] == palette["figure.facecolor"]
+        assert mpl.rcParams["axes.facecolor"] == palette["axes.facecolor"]
+        assert mpl.rcParams["text.color"] == palette["text.color"]
+        assert mpl.rcParams["axes.prop_cycle"].by_key()["color"] == palette[
+            "colors"]
+
+
+def test_apply_figure_theme_updates_existing_plot_elements():
+    with mpl.rc_context():
+        figure, axes = plt.subplots()
+        axes.plot([1, 2], [3, 4], label="data")
+        axes.set_xlabel("Simulation step")
+        axes.set_ylabel("Energy")
+        axes.text(
+            2,
+            4,
+            "4.000e+00",
+            bbox=dict(facecolor="white", edgecolor="white"),
+        )
+        axes.legend()
+
+        palette = theme.apply_figure_theme(figure, axes, "Dark")
+
+        assert figure.get_facecolor() == to_rgba(palette["figure.facecolor"])
+        assert axes.get_facecolor() == to_rgba(palette["axes.facecolor"])
+        assert axes.xaxis.label.get_color() == palette["axes.labelcolor"]
+        assert axes.yaxis.label.get_color() == palette["axes.labelcolor"]
+        assert axes.get_legend().get_texts()[0].get_color() == palette[
+            "text.color"]
+        assert axes.texts[0].get_color() == palette["text.color"]
+        assert axes.texts[0].get_bbox_patch().get_alpha() == 0.85


### PR DESCRIPTION
## Summary
- Add a matplotlib theme adapter for CustomTkinter light, dark, and system appearance modes.
- Apply the active plot palette when the GUI starts, when plots are created, and when the appearance mode changes.
- Redraw existing plot windows on appearance changes without re-reading files.
- Cover palette resolution, existing-figure styling, and GUI callback behavior with tests.

Closes #35.

## Verification
- python -m pytest tests/apps/test_app.py tests/plots/test_gui_plots.py tests/plots/test_theme.py
- git diff --check
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing
- python -m pytest
- python -m build