### PR TITLE
Add self-correlation mean statistic

### DIFF
--- a/PQEnalyzer/apps/app_layout.py
+++ b/PQEnalyzer/apps/app_layout.py
@@ -310,13 +310,13 @@ class StatisticsControlsView:
                                      padx=10,
                                      pady=5,
                                      sticky="w")
-        self.auto_correlation = ctk.CTkCheckBox(self.frame,
-                                                text="Auto Correlation")
-        self.auto_correlation.grid(row=4,
-                                   column=0,
-                                   padx=10,
-                                   pady=5,
-                                   sticky="w")
+        self.self_correlation_mean = ctk.CTkCheckBox(
+            self.frame, text="Self-Correlation Mean")
+        self.self_correlation_mean.grid(row=4,
+                                           column=0,
+                                           padx=10,
+                                           pady=5,
+                                           sticky="w")
 
         self.window_size = None
         self.running_average = ctk.CTkCheckBox(
@@ -355,7 +355,7 @@ class StatisticsControlsView:
         app.mean = self.mean
         app.median = self.median
         app.cummulative_average = self.cumulative_average
-        app.auto_correlation = self.auto_correlation
+        app.self_correlation_mean = self.self_correlation_mean
         app.running_average = self.running_average
         app.running_average_window_size_label = self.window_size_label
         app.window_size = self.window_size

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -95,7 +95,8 @@ class Plot(metaclass=ABCMeta):
         self.mean = self.app.mean.get()
         self.median = self.app.median.get()
         self.cummulative_average = self.app.cummulative_average.get()
-        self.auto_correlation = self.app.auto_correlation.get()
+        self.self_correlation_mean = (
+            self.app.self_correlation_mean.get())
         self.running_average = self.app.running_average.get()
         self.window_size = self.app.window_size.get()
 

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -144,14 +144,13 @@ class PlotTime(Plot):
 
             self.add_value_label(x, y)
 
-        if self.auto_correlation:
-            # calculate auto correlation and plot
-            x, y = Statistic.auto_correlation_values(energy_series.time,
-                                                     energy_series.values)
+        if self.self_correlation_mean:
+            x, y = Statistic.self_correlation_mean_values(
+                energy_series.time, energy_series.values)
             self.ax.plot(
                 x,
                 y,
-                label="Auto Correlation",
+                label="Self-Correlation Mean",
                 linestyle="--",
             )
 

--- a/PQEnalyzer/statistics/statistic.py
+++ b/PQEnalyzer/statistics/statistic.py
@@ -31,10 +31,10 @@ class Statistic:
         Calculate cumulative average values for numeric arrays.
     cummulative_average(energies, info_parameter)
         Backward-compatible alias for cumulative_average.
-    auto_correlation(energies, info_parameter)
-        Calculate normalized autocorrelation for a Reader energy parameter.
-    auto_correlation_values(time, values)
-        Calculate normalized autocorrelation for numeric arrays.
+    self_correlation_mean(energies, info_parameter)
+        Calculate a self-correlation mean for a Reader energy parameter.
+    self_correlation_mean_values(time, values)
+        Calculate a self-correlation mean for numeric arrays.
     running_average(energies, info_parameter, window_size)
         Calculate a centered running average for a Reader energy parameter.
     running_average_values(time, values, window_size)
@@ -155,7 +155,7 @@ class Statistic:
         Examples
         --------
         >>> Statistic.cumulative_average(energies, "ENERGY")
-        ([1, 2, 3, 4, 5], [2.1666, 2.8571, 3.6666, 4., 4.3333])
+        ([1, 2, 3, 4, 5], [1, 1.5, 2, 2.5, 3])
         """
 
         energy_series = concatenate_series(energies, info_parameter)
@@ -185,57 +185,55 @@ class Statistic:
         return Statistic.cumulative_average(energies, info_parameter)
 
     @staticmethod
-    def auto_correlation(energies, info_parameter) -> tuple:
+    def self_correlation_mean(energies, info_parameter) -> tuple:
         """
-        Calculate the normalized autocorrelation of the data.
+        Calculate the self-correlation mean of the data.
 
         Parameters
         ----------
         energies : list
             A list of energy objects.
         info_parameter : str
-            The info parameter to calculate the auto correlation of.
+            The info parameter to calculate the self-correlation mean of.
 
         Returns
         -------
         tuple
-            A tuple containing the time and normalized autocorrelation data.
+            A tuple containing the time and self-correlation mean.
 
         Examples
         --------
-        >>> Statistic.auto_correlation(energies, "ENERGY")
-        ([1, 2, 3, 4, 5], [1., 0.4, -0.1, -0.4, -0.4])
+        >>> Statistic.self_correlation_mean(energies, "ENERGY")
+        ([1, 2, 3, 4, 5], [8.6666, 10, 11, 10, 8.6666])
         """
 
         energy_series = concatenate_series(energies, info_parameter)
-        return Statistic.auto_correlation_values(energy_series.time,
-                                                 energy_series.values)
+        return Statistic.self_correlation_mean_values(
+            energy_series.time, energy_series.values)
 
     @staticmethod
-    def auto_correlation_values(time, values) -> tuple:
+    def self_correlation_mean_values(time, values) -> tuple:
         """
-        Calculate the normalized autocorrelation for a numeric series.
+        Calculate the self-correlation mean for a numeric series.
 
-        Constant series are reported as a unit impulse: one at zero lag and
-        zero afterwards. That keeps the result finite and plot-friendly.
+        The result is divided by the number of overlapping points at each lag
+        so every point is a mean product rather than an edge-biased sum.
         """
 
         time, data = Statistic.__arrays(time, values)
         data = data.astype(float)
 
-        centered_data = data - np.mean(data)
-        zero_lag_correlation = np.dot(centered_data, centered_data)
+        numerator = np.correlate(data, data, mode="same")
+        denominator = np.correlate(
+            np.ones_like(data), np.ones_like(data), mode="same")
+        self_correlation_mean = np.divide(
+            numerator,
+            denominator,
+            out=np.zeros_like(data),
+            where=denominator != 0,
+        )
 
-        if zero_lag_correlation == 0:
-            auto_correlation = np.zeros_like(data)
-            auto_correlation[0] = 1
-        else:
-            auto_correlation = (
-                np.correlate(centered_data, centered_data,
-                             mode="full")[len(data) - 1:] /
-                zero_lag_correlation)
-
-        return time, auto_correlation
+        return time, self_correlation_mean
 
     @staticmethod
     def running_average(energies, info_parameter, window_size) -> tuple:

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -244,7 +244,7 @@ def test_statistics_controls_view_exposes_plot_state_attributes(monkeypatch):
     assert app.mean is view.mean
     assert app.median is view.median
     assert app.cummulative_average is view.cumulative_average
-    assert app.auto_correlation is view.auto_correlation
+    assert app.self_correlation_mean is view.self_correlation_mean
     assert app.running_average is view.running_average
     assert app.window_size is view.window_size
 

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -53,7 +53,7 @@ class FakeApp:
         mean=False,
         median=False,
         cummulative_average=False,
-        auto_correlation=False,
+        self_correlation_mean=False,
         running_average=False,
         window_size="",
     ):
@@ -61,7 +61,7 @@ class FakeApp:
         self.mean = FakeFlag(mean)
         self.median = FakeFlag(median)
         self.cummulative_average = FakeFlag(cummulative_average)
-        self.auto_correlation = FakeFlag(auto_correlation)
+        self.self_correlation_mean = FakeFlag(self_correlation_mean)
         self.running_average = FakeFlag(running_average)
         self.window_size = FakeEntry(window_size)
         self.plot_main_data = FakeFlag(False)
@@ -109,7 +109,7 @@ def test_time_statistics_draw_expected_overlay_series():
         mean=True,
         median=True,
         cummulative_average=True,
-        auto_correlation=True,
+        self_correlation_mean=True,
         running_average=True,
         window_size="2",
     )
@@ -121,6 +121,22 @@ def test_time_statistics_draw_expected_overlay_series():
         "Mean",
         "Median",
         "Cumulative Average",
-        "Auto Correlation",
+        "Self-Correlation Mean",
         "Running Average (2)",
     ]
+
+
+def test_time_self_correlation_mean_uses_data_scale():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4, 5])],
+                  self_correlation_mean=True)
+    plot = PlotTime(app)
+
+    plot.statistics("PARAMETER")
+
+    line = plot.ax.lines[0]
+
+    assert line.get_label() == "Self-Correlation Mean"
+    assert np.all(line.get_xdata() == [1, 2, 3, 4, 5])
+    assert np.allclose(line.get_ydata(),
+                       [8.6666, 10, 11, 10, 8.6666],
+                       rtol=1e-4)

--- a/tests/statistics/test_statistic.py
+++ b/tests/statistics/test_statistic.py
@@ -74,38 +74,52 @@ class TestStatistic:
         assert np.all(old_time == new_time)
         assert np.all(old_average == new_average)
 
-    def test_auto_correlation(self):
-        time, auto_correlation = Statistic.auto_correlation_values(
-            [1, 2, 3, 4, 5], [1, 2, 3, 4, 5])
+    def test_self_correlation_mean(self):
+        time, self_correlation_mean = (
+            Statistic.self_correlation_mean_values(
+                [1, 2, 3, 4, 5], [1, 2, 3, 4, 5]))
         assert np.all(time == [1, 2, 3, 4, 5])
-        assert np.allclose(auto_correlation, [1, 0.4, -0.1, -0.4, -0.4])
+        assert np.allclose(
+            self_correlation_mean,
+            [8.6666, 10, 11, 10, 8.6666],
+            rtol=1e-4,
+        )
 
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
-        time, auto_correlation = Statistic.auto_correlation(
-            energies, "SIMULATION-TIME")
+        time, self_correlation_mean = (
+            Statistic.self_correlation_mean(energies, "SIMULATION-TIME"))
         assert np.all(time == [1, 2, 3, 4, 5])
-        assert np.allclose(auto_correlation, [1, 0.4, -0.1, -0.4, -0.4])
+        assert np.allclose(
+            self_correlation_mean,
+            [8.6666, 10, 11, 10, 8.6666],
+            rtol=1e-4,
+        )
 
         energies2 = Reader(["tests/data/md-02.en"], MDEngineFormat.PQ).energies
-        time, auto_correlation = Statistic.auto_correlation(
-            energies2, "SIMULATION-TIME")
+        time, self_correlation_mean = (
+            Statistic.self_correlation_mean(energies2, "SIMULATION-TIME"))
         assert np.all(time == [6, 7, 8, 9, 10])
-        assert np.allclose(auto_correlation, [1, 0.4, -0.1, -0.4, -0.4])
+        assert np.allclose(
+            self_correlation_mean,
+            [63.6666, 65, 66, 65, 63.6666],
+            rtol=1e-4,
+        )
 
-    def test_auto_correlation_constant_data(self):
-        time, auto_correlation = Statistic.auto_correlation_values(
-            [1, 2, 3, 4, 5], [2, 2, 2, 2, 2])
+    def test_self_correlation_mean_constant_data(self):
+        time, self_correlation_mean = (
+            Statistic.self_correlation_mean_values(
+                [1, 2, 3, 4, 5], [2, 2, 2, 2, 2]))
 
         assert np.all(time == [1, 2, 3, 4, 5])
-        assert np.all(auto_correlation == [1, 0, 0, 0, 0])
+        assert np.all(self_correlation_mean == [4, 4, 4, 4, 4])
 
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
 
-        time, auto_correlation = Statistic.auto_correlation(
-            energies, "E(INTRA)")
+        time, self_correlation_mean = (
+            Statistic.self_correlation_mean(energies, "E(INTRA)"))
 
         assert np.all(time == [1, 2, 3, 4, 5])
-        assert np.all(auto_correlation == [1, 0, 0, 0, 0])
+        assert np.all(self_correlation_mean == [0, 0, 0, 0, 0])
 
     def test_running_average(self):
         time, running_average = Statistic.running_average_values(


### PR DESCRIPTION
## Summary
- Replace the misleading auto-correlation statistic with an overlap-corrected Self-Correlation Mean.
- Use the defensible overlap denominator, not a data-dependent signal denominator.
- Keep the GUI statistic and plot label aligned with the implemented formula.
- Handle zero-valued series without NaN values.

Closes #55.

## Verification
- python -m pytest tests/statistics/test_statistic.py tests/plots/test_gui_plots.py tests/apps/test_app.py
- git diff --check
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing
- python -m pytest
- python -m build