### PR TITLE
Clean up plot presentation

### DIFF
--- a/PQEnalyzer/plots/labels.py
+++ b/PQEnalyzer/plots/labels.py
@@ -1,0 +1,86 @@
+"""
+Helpers for concise but unambiguous plot labels.
+"""
+
+import os
+from collections import defaultdict
+from pathlib import Path
+
+
+def unique_path_labels(filenames):
+    """
+    Return concise path labels that distinguish duplicated basenames.
+    """
+
+    filenames = list(filenames)
+    if not filenames:
+        return []
+
+    path_parts = [_label_parts(filename) for filename in filenames]
+    labels = [None] * len(path_parts)
+
+    groups = defaultdict(list)
+    for index, parts in enumerate(path_parts):
+        groups[_suffix_label(parts, 1)].append((index, parts))
+
+    for members in groups.values():
+        if len(members) == 1:
+            index, parts = members[0]
+            labels[index] = _suffix_label(parts, 1)
+            continue
+
+        for index, label in _unique_group_labels(members):
+            labels[index] = label
+
+    return labels
+
+
+def _unique_group_labels(members):
+    max_depth = max(len(parts) for _, parts in members)
+
+    for depth in range(2, max_depth + 1):
+        labels = [_suffix_label(parts, depth) for _, parts in members]
+        if len(set(labels)) == len(labels):
+            return [
+                (index, label)
+                for (index, _), label in zip(members, labels)
+            ]
+
+    labels = _deduplicate([
+        _suffix_label(parts, max_depth)
+        for _, parts in members
+    ])
+
+    return [
+        (index, label)
+        for (index, _), label in zip(members, labels)
+    ]
+
+
+def _label_parts(filename):
+    path = Path(filename)
+    parts = [part for part in path.parts if part != path.anchor]
+
+    if not parts:
+        return [str(filename)]
+
+    return parts
+
+
+def _suffix_label(parts, depth):
+    suffix = parts[-min(depth, len(parts)):]
+    return os.path.join(*suffix)
+
+
+def _deduplicate(labels):
+    seen = {}
+    unique_labels = []
+
+    for label in labels:
+        seen[label] = seen.get(label, 0) + 1
+        if seen[label] == 1:
+            unique_labels.append(label)
+        else:
+            unique_labels.append(f"{label} ({seen[label]})")
+
+    return unique_labels

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -54,7 +54,7 @@ class Plot(metaclass=ABCMeta):
 
         # create the plot
         apply_matplotlib_theme(getattr(self.app, "appearance_mode", None))
-        self.figure = plt.figure()
+        self.figure = plt.figure(figsize=(9, 5.5))
         self.ax = self.figure.add_subplot(111)
         self.apply_theme()
 
@@ -213,8 +213,26 @@ class Plot(metaclass=ABCMeta):
 
         self.labels(self.info_parameter)
         self.apply_theme()
+        self.figure.tight_layout()
 
         return None
+
+    def show_legend(self, **kwargs) -> bool:
+        """
+        Draw a consistently styled legend when plotted labels exist.
+        """
+
+        _, labels = self.ax.get_legend_handles_labels()
+        if not labels:
+            return False
+
+        legend_options = {
+            "fontsize": "small",
+            "frameon": True,
+        }
+        legend_options.update(kwargs)
+        self.ax.legend(**legend_options)
+        return True
 
     def apply_theme(self) -> None:
         """

--- a/PQEnalyzer/plots/plot_histogram.py
+++ b/PQEnalyzer/plots/plot_histogram.py
@@ -1,14 +1,13 @@
 """
 Histogram/KDE plotting for PQ energy parameters.
 """
-
-import os
 from scipy.stats import gaussian_kde
 import numpy as np
 
 from ..statistics import Statistic
 from ..energy_access import concatenate_series, parameter_unit, parameter_values
 from .._logging import get_logger
+from .labels import unique_path_labels
 from .plot import Plot
 
 
@@ -58,8 +57,8 @@ class PlotHistogram(Plot):
         None
         """
 
+        labels = unique_path_labels(self.reader.filenames)
         for i, energy in enumerate(self.reader.energies):
-            basename = os.path.basename(self.reader.filenames[i])
             data = parameter_values(energy, info_parameter)
 
             # check if zero data
@@ -77,7 +76,7 @@ class PlotHistogram(Plot):
             )
 
             y = kde(x)
-            self.ax.plot(x, y, label=f"{basename} KDE")
+            self.ax.plot(x, y, label=f"{labels[i]} KDE")
 
         return None
 
@@ -104,18 +103,11 @@ class PlotHistogram(Plot):
             f"{parameter_unit(self.reader.energies[0], info_parameter)}"
         )
 
-        # Check if label is empty
-        if self.ax.get_legend_handles_labels()[1] == []:
+        _, labels = self.ax.get_legend_handles_labels()
+        if not labels:
             logger.warning("No data to plot.")
         else:
-            # legend outside of plot
-            self.ax.legend(
-                loc="upper center",
-                bbox_to_anchor=(0.5, 1.15),
-                ncol=5,
-                fancybox=True,
-                shadow=True,
-            )
+            self.show_legend(loc="best", ncol=min(3, len(labels)))
 
         return None
 
@@ -140,23 +132,12 @@ class PlotHistogram(Plot):
             # calculate mean and plot
             _, y = Statistic.mean_values(energy_series.time,
                                          energy_series.values)
-            self.ax.vlines(float(y[0]),
-                           0,
-                           self.ax.get_ylim()[1],
-                           label="Mean",
-                           linestyles="--",
-                           colors="blue")
+            self.ax.axvline(float(y[0]), label="Mean", linestyle="--")
 
         if self.median:
             # calculate median and plot
             _, y = Statistic.median_values(energy_series.time,
                                            energy_series.values)
-            # plot dependent y_max of histogram
-            self.ax.vlines(float(y[0]),
-                           0,
-                           self.ax.get_ylim()[1],
-                           label="Median",
-                           linestyles="--",
-                           colors="red")
+            self.ax.axvline(float(y[0]), label="Median", linestyle="--")
 
         return None

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -5,6 +5,7 @@ Time-series plotting for PQ energy parameters.
 from ..statistics import Statistic
 from ..energy_access import concatenate_series, parameter_unit, series
 from .._logging import get_logger
+from .labels import unique_path_labels
 from .plot import Plot
 
 
@@ -53,14 +54,15 @@ class PlotTime(Plot):
         None
         """
 
+        labels = unique_path_labels(self.reader.filenames)
         for i, energy in enumerate(self.reader.energies):
             energy_series = series(energy, info_parameter)
             self.ax.plot(
                 energy_series.time,
                 energy_series.values,
-                label=self.reader.filenames[i],
+                label=labels[i],
             )
-        self.add_value_label(energy_series.time, energy_series.values)
+            self.add_value_label(energy_series.time, energy_series.values)
 
     def labels(self, info_parameter: str) -> None:
         """
@@ -85,16 +87,8 @@ class PlotTime(Plot):
             f"{parameter_unit(self.reader.energies[0], info_parameter)}"
         )
 
-        # Check if label is empty
-        if self.ax.get_legend_handles_labels()[1] == []:
+        if not self.show_legend(loc="best"):
             logger.warning("No data to plot.")
-        else:
-            # legend outside of plot
-            self.ax.legend(
-                fontsize="small",
-                fancybox=True,
-                shadow=True,
-            )
 
         return None
 
@@ -211,12 +205,14 @@ class PlotTime(Plot):
         None
         """
 
-        self.ax.text(
-            self.ax.get_xlim()[1],
-            y[-1],
+        self.ax.annotate(
             f"{y[-1]:.3e}",
+            xy=(x[-1], y[-1]),
+            xytext=(6, 0),
+            textcoords="offset points",
             fontsize=8,
             horizontalalignment="left",
+            verticalalignment="center",
             bbox=dict(facecolor="white", alpha=0.5, edgecolor="white"),
         )
 

--- a/PQEnalyzer/plots/termplot.py
+++ b/PQEnalyzer/plots/termplot.py
@@ -1,11 +1,10 @@
 """
 Terminal plotting implementation.
 """
-
-import os
 import plotext as plt
 
 from ..energy_access import parameter_unit, series
+from .labels import unique_path_labels
 
 
 class TermPlot:
@@ -43,13 +42,13 @@ class TermPlot:
             The information parameter to plot.
 
         """
+        labels = unique_path_labels(self.reader.filenames)
         for i, energy in enumerate(self.reader.energies):
-            basename = os.path.basename(self.reader.filenames[i])
             energy_series = series(energy, info_parameter)
             plt.plot(
                 energy_series.time,
                 energy_series.values,
-                label=basename,
+                label=labels[i],
             )
             plt.xlabel("Simulation Time")
             plt.ylabel(

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -34,11 +34,14 @@ class FakeEnergy:
 
 class FakeReader:
 
-    def __init__(self, energies):
+    def __init__(self, energies, filenames=None):
         self.energies = energies
-        self.filenames = [
-            f"/tmp/series-{index}.en" for index, _ in enumerate(energies)
-        ]
+        if filenames is None:
+            filenames = [
+                f"/tmp/series-{index}.en"
+                for index, _ in enumerate(energies)
+            ]
+        self.filenames = filenames
 
     def read_last(self):
         return None
@@ -56,8 +59,9 @@ class FakeApp:
         self_correlation_mean=False,
         running_average=False,
         window_size="",
+        filenames=None,
     ):
-        self.reader = FakeReader(energies)
+        self.reader = FakeReader(energies, filenames)
         self.mean = FakeFlag(mean)
         self.median = FakeFlag(median)
         self.cummulative_average = FakeFlag(cummulative_average)
@@ -81,15 +85,56 @@ def test_histogram_skips_constant_series_and_plots_remaining_data(caplog):
     assert "Data zero. No histogram available." in caplog.text
 
 
+def test_histogram_disambiguates_duplicate_filenames():
+    app = FakeApp(
+        [FakeEnergy([1, 2, 3, 4]), FakeEnergy([2, 3, 4, 5])],
+        filenames=["/tmp/run-a/md.en", "/tmp/run-b/md.en"],
+    )
+    plot = PlotHistogram(app)
+
+    plot.main_data("PARAMETER")
+
+    assert plot.ax.get_legend_handles_labels()[1] == [
+        "run-a/md.en KDE",
+        "run-b/md.en KDE",
+    ]
+
+
 def test_histogram_statistics_draw_single_mean_and_median_lines():
     app = FakeApp([FakeEnergy([1, 2, 3, 4])], mean=True, median=True)
     plot = PlotHistogram(app)
 
     plot.statistics("PARAMETER")
 
-    assert len(plot.ax.collections) == 2
-    assert len(plot.ax.collections[0].get_segments()) == 1
-    assert len(plot.ax.collections[1].get_segments()) == 1
+    assert plot.ax.get_legend_handles_labels()[1] == ["Mean", "Median"]
+    assert len(plot.ax.lines) == 2
+    assert all(line.get_linestyle() == "--" for line in plot.ax.lines)
+
+
+def test_time_main_data_uses_readable_filenames_and_value_labels():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])])
+    plot = PlotTime(app)
+
+    plot.main_data("PARAMETER")
+
+    assert plot.ax.get_legend_handles_labels()[1] == ["series-0.en"]
+    assert len(plot.ax.texts) == 1
+    assert plot.ax.texts[0].get_text() == "4.000e+00"
+
+
+def test_time_main_data_disambiguates_duplicate_filenames():
+    app = FakeApp(
+        [FakeEnergy([1, 2, 3, 4]), FakeEnergy([2, 3, 4, 5])],
+        filenames=["/tmp/run-a/md.en", "/tmp/run-b/md.en"],
+    )
+    plot = PlotTime(app)
+
+    plot.main_data("PARAMETER")
+
+    assert plot.ax.get_legend_handles_labels()[1] == [
+        "run-a/md.en",
+        "run-b/md.en",
+    ]
 
 
 def test_running_average_rejects_invalid_window_size_without_crashing(caplog):

--- a/tests/plots/test_labels.py
+++ b/tests/plots/test_labels.py
@@ -1,0 +1,33 @@
+from PQEnalyzer.plots.labels import unique_path_labels
+
+
+def test_unique_path_labels_keep_unique_basenames():
+    labels = unique_path_labels(["/tmp/a/md-01.en", "/tmp/b/md-02.en"])
+
+    assert labels == ["md-01.en", "md-02.en"]
+
+
+def test_unique_path_labels_use_parent_for_duplicate_basenames():
+    labels = unique_path_labels(["/tmp/run-a/md.en", "/tmp/run-b/md.en"])
+
+    assert labels == ["run-a/md.en", "run-b/md.en"]
+
+
+def test_unique_path_labels_keep_unrelated_unique_basenames_short():
+    labels = unique_path_labels([
+        "/tmp/water/run-001/energy.out",
+        "/tmp/methanol/run-001/energy.out",
+        "/tmp/water/run-002/forces.out",
+    ])
+
+    assert labels == [
+        "water/run-001/energy.out",
+        "methanol/run-001/energy.out",
+        "forces.out",
+    ]
+
+
+def test_unique_path_labels_number_identical_paths():
+    labels = unique_path_labels(["/tmp/run/md.en", "/tmp/run/md.en"])
+
+    assert labels == ["tmp/run/md.en", "tmp/run/md.en (2)"]


### PR DESCRIPTION
## Summary
- Use concise plot labels while disambiguating duplicate basenames with the shortest unique path suffix.
- Apply the same label behavior to time-series, histogram, and terminal plots.
- Add a shared legend helper and consistent plot sizing/layout.
- Move value labels to offset annotations at the actual last data point.
- Remove hard-coded histogram statistic colors so theme colors apply consistently.

Closes #54.

## Verification
- `python -m pytest tests/plots/test_gui_plots.py tests/plots/test_labels.py tests/plots/test_theme.py`
- `git diff --check`
- `python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing`
- `python -m pytest`
- `python -m build`
