### PR TITLE
Add live dashboard focus plots

### DIFF
--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -8,7 +8,8 @@ import customtkinter as ctk
 import matplotlib.pyplot as plt
 
 from .._logging import get_logger
-from ..plots import PlotTime, PlotHistogram
+from ..plots import PlotDashboard, PlotTime, PlotHistogram
+from ..plots.options import PlotOptions
 from ..plots.theme import apply_matplotlib_theme, resolve_appearance_mode
 from .app_layout import (
     configure_default_theme,
@@ -58,6 +59,8 @@ class App(ctk.CTk):
         ][1:]
 
         self.list_of_plots = []
+        self.selected_plot = None
+        self.__syncing_plot_controls = False
 
         signal.signal(signal.SIGINT,
                       lambda sig, frame: self.destroy())
@@ -80,7 +83,8 @@ class App(ctk.CTk):
             self, self.__plot_button_event, self.__refresh_plots)
         self.parameter_selector_view = ParameterSelectorView(
             self, self.__change_info_event)
-        self.statistics_controls_view = StatisticsControlsView(self)
+        self.statistics_controls_view = StatisticsControlsView(
+            self, self.__statistics_control_event)
 
     def validate_number(self, value):
         """
@@ -145,10 +149,19 @@ class App(ctk.CTk):
         """
         Refresh open plots and forget plots whose windows were closed.
         """
-        for plot in self.list_of_plots:
+        selected_plot = self.__dict__.get("selected_plot")
+        if (
+            selected_plot is not None
+            and selected_plot.figure.number in plt.get_fignums()
+        ):
+            selected_plot.options = PlotOptions.from_app(self)
+
+        for plot in list(self.list_of_plots):
 
             if plot.figure.number not in plt.get_fignums():
                 self.list_of_plots.remove(plot)
+                if plot is self.__dict__.get("selected_plot"):
+                    self.select_plot(None)
                 continue
 
             plot.refresh()
@@ -161,6 +174,8 @@ class App(ctk.CTk):
 
             if plot.figure.number not in plt.get_fignums():
                 self.list_of_plots.remove(plot)
+                if plot is self.__dict__.get("selected_plot"):
+                    self.select_plot(None)
                 continue
 
             plot.redraw()
@@ -180,6 +195,8 @@ class App(ctk.CTk):
             plot_factory = PlotTime
         elif event == 1:
             plot_factory = PlotHistogram
+        elif event == 2:
+            plot_factory = PlotDashboard
         else:
             raise ValueError(f"Unknown plot event: {event}")
 
@@ -196,7 +213,125 @@ class App(ctk.CTk):
 
         self.list_of_plots.append(plot)
 
-        if interval is not None:
-            plot.follow(self.__selected_info, interval)
+        if event == 2:
+            self.select_plot(None)
+            info_parameter = None
         else:
-            plot.simple(self.__selected_info)
+            info_parameter = self.__selected_info
+
+        if interval is not None:
+            plot.follow(info_parameter, interval)
+        else:
+            plot.simple(info_parameter)
+
+    def open_focus_plot(self, info_parameter):
+        """
+        Open a focused time-series plot for one dashboard parameter.
+        """
+
+        interval = None
+        if self.follow.get():
+            try:
+                interval = self.parse_positive_float(
+                    self.interval.get(), 1.0, "Interval")
+            except ValueError as error:
+                logger.warning("%s", error)
+                return None
+
+        self.__change_info_event(info_parameter)
+        plot = PlotTime(self)
+        self.list_of_plots.append(plot)
+
+        if interval is not None:
+            plot.follow(info_parameter, interval)
+        else:
+            plot.simple(info_parameter)
+
+    def select_plot(self, plot):
+        """
+        Select a focused plot and mirror its options into the GUI controls.
+        """
+
+        if plot is not None and plot.figure.number not in plt.get_fignums():
+            plot = None
+
+        self.selected_plot = plot
+        if plot is None:
+            return
+
+        self.__sync_plot_controls(plot.options)
+
+    def __statistics_control_event(self):
+        """
+        Apply changed statistic controls to the selected focused plot.
+        """
+
+        if self.__syncing_plot_controls:
+            return None
+
+        if self.difference.get():
+            self.plot_main_data.set(True)
+
+        if self.selected_plot is None:
+            return None
+
+        if self.selected_plot.figure.number not in plt.get_fignums():
+            self.select_plot(None)
+            return None
+
+        self.selected_plot.redraw(options=PlotOptions.from_app(self))
+
+    def __sync_plot_controls(self, options):
+        """
+        Update GUI statistic controls from one plot's stored options.
+        """
+
+        self.__syncing_plot_controls = True
+        try:
+            self.__set_checkbox(self.mean, options.mean)
+            self.__set_checkbox(self.median, options.median)
+            self.__set_checkbox(
+                self.cummulative_average,
+                options.cummulative_average,
+            )
+            self.__set_checkbox(
+                self.self_correlation_mean,
+                options.self_correlation_mean,
+            )
+            self.__set_checkbox(self.difference, options.difference)
+            self.__set_checkbox(self.running_average,
+                                options.running_average)
+            self.__set_checkbox(self.plot_main_data, options.plot_main)
+            self.__set_entry(self.window_size, options.window_size)
+            if options.running_average:
+                self.window_size.configure(state="normal")
+            else:
+                self.window_size.configure(state="disabled")
+        finally:
+            self.__syncing_plot_controls = False
+
+    def __set_checkbox(self, checkbox, value):
+        """
+        Set a checkbox-like widget without invoking its command.
+        """
+
+        if value:
+            if hasattr(checkbox, "select"):
+                checkbox.select()
+            else:
+                checkbox.set(True)
+        else:
+            if hasattr(checkbox, "deselect"):
+                checkbox.deselect()
+            else:
+                checkbox.set(False)
+
+    def __set_entry(self, entry, value):
+        """
+        Replace the text of an entry-like widget.
+        """
+
+        entry.configure(state="normal")
+        entry.delete(0, ctk.END)
+        if value:
+            entry.insert(0, value)

--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -11,6 +11,7 @@ from .._logging import get_logger
 from ..plots import PlotDashboard, PlotTime, PlotHistogram
 from ..plots.options import PlotOptions
 from ..plots.theme import apply_matplotlib_theme, resolve_appearance_mode
+from .file_watcher import FileChangeWatcher
 from .app_layout import (
     configure_default_theme,
     configure_window,
@@ -61,6 +62,8 @@ class App(ctk.CTk):
         self.list_of_plots = []
         self.selected_plot = None
         self.__syncing_plot_controls = False
+        self.__file_watcher = None
+        self.__auto_refresh_after_id = None
 
         signal.signal(signal.SIGINT,
                       lambda sig, frame: self.destroy())
@@ -69,6 +72,7 @@ class App(ctk.CTk):
         """
         Destroy the app.
         """
+        self.__stop_file_watcher()
         plt.close("all")
         self.quit()
         super().destroy()
@@ -80,11 +84,16 @@ class App(ctk.CTk):
         self.sidebar_view = SidebarView(
             self, self.__change_appearance_mode_event)
         self.plot_controls_view = PlotControlsView(
-            self, self.__plot_button_event, self.__refresh_plots)
+            self,
+            self.__plot_button_event,
+            self.__auto_refresh_control_event,
+        )
         self.parameter_selector_view = ParameterSelectorView(
             self, self.__change_info_event)
         self.statistics_controls_view = StatisticsControlsView(
             self, self.__statistics_control_event)
+        if "auto_refresh" in self.__dict__:
+            self.__auto_refresh_control_event()
 
     def validate_number(self, value):
         """
@@ -145,7 +154,7 @@ class App(ctk.CTk):
 
         self.__selected_info = new_info
 
-    def __refresh_plots(self):
+    def __refresh_plots(self, show=True):
         """
         Refresh open plots and forget plots whose windows were closed.
         """
@@ -164,7 +173,96 @@ class App(ctk.CTk):
                     self.select_plot(None)
                 continue
 
-            plot.refresh()
+            plot.refresh(show=show)
+
+    def __schedule_auto_refresh(self):
+        """
+        Debounce file-change events into one GUI-thread refresh.
+        """
+
+        if not self.auto_refresh.get():
+            return None
+
+        if self.__auto_refresh_after_id is not None:
+            self.after_cancel(self.__auto_refresh_after_id)
+
+        self.__auto_refresh_after_id = self.after(
+            250,
+            self.__auto_refresh_plots,
+        )
+
+        return None
+
+    def __auto_refresh_plots(self):
+        """
+        Refresh plots after a watched input file changes.
+        """
+
+        self.__auto_refresh_after_id = None
+        self.__refresh_plots(show=False)
+
+        return None
+
+    def __auto_refresh_control_event(self):
+        """
+        Start or stop file watching from the Auto-Refresh checkbox.
+        """
+
+        if self.auto_refresh.get():
+            if self.__start_file_watcher():
+                self.__set_auto_refresh_status("Watching for file changes")
+        else:
+            self.__stop_file_watcher()
+            self.__set_auto_refresh_status("Auto-refresh paused")
+
+        return None
+
+    def __start_file_watcher(self):
+        """
+        Start watching the currently loaded files.
+        """
+
+        if self.__file_watcher is not None:
+            return True
+
+        watcher = FileChangeWatcher(
+            self.reader.filenames,
+            self.__schedule_auto_refresh,
+        )
+        if watcher.start():
+            self.__file_watcher = watcher
+            return True
+        else:
+            self.__set_checkbox(self.auto_refresh, False)
+            self.__set_auto_refresh_status("Auto-refresh unavailable")
+
+        return False
+
+    def __stop_file_watcher(self):
+        """
+        Stop the active file watcher, if any.
+        """
+
+        if self.__dict__.get("_App__auto_refresh_after_id") is not None:
+            self.after_cancel(self.__auto_refresh_after_id)
+            self.__auto_refresh_after_id = None
+
+        if self.__dict__.get("_App__file_watcher") is None:
+            return None
+
+        self.__file_watcher.stop()
+        self.__file_watcher = None
+
+        return None
+
+    def __set_auto_refresh_status(self, message):
+        """
+        Update the Auto-Refresh status label when the view exists.
+        """
+
+        status_label = self.__dict__.get("auto_refresh_status_label")
+        if status_label is not None:
+            status_label.configure(text=message)
 
     def __redraw_plots(self):
         """
@@ -200,15 +298,6 @@ class App(ctk.CTk):
         else:
             raise ValueError(f"Unknown plot event: {event}")
 
-        interval = None
-        if self.follow.get():
-            try:
-                interval = self.parse_positive_float(
-                    self.interval.get(), 1.0, "Interval")
-            except ValueError as error:
-                logger.warning("%s", error)
-                return None
-
         plot = plot_factory(self)
 
         self.list_of_plots.append(plot)
@@ -219,33 +308,18 @@ class App(ctk.CTk):
         else:
             info_parameter = self.__selected_info
 
-        if interval is not None:
-            plot.follow(info_parameter, interval)
-        else:
-            plot.simple(info_parameter)
+        plot.simple(info_parameter)
 
     def open_focus_plot(self, info_parameter):
         """
         Open a focused time-series plot for one dashboard parameter.
         """
 
-        interval = None
-        if self.follow.get():
-            try:
-                interval = self.parse_positive_float(
-                    self.interval.get(), 1.0, "Interval")
-            except ValueError as error:
-                logger.warning("%s", error)
-                return None
-
         self.__change_info_event(info_parameter)
         plot = PlotTime(self)
         self.list_of_plots.append(plot)
 
-        if interval is not None:
-            plot.follow(info_parameter, interval)
-        else:
-            plot.simple(info_parameter)
+        plot.simple(info_parameter)
 
     def select_plot(self, plot):
         """

--- a/PQEnalyzer/apps/app_layout.py
+++ b/PQEnalyzer/apps/app_layout.py
@@ -125,7 +125,7 @@ class PlotControlsView:
                         sticky="nsew",
                         padx=(20, 20),
                         pady=(10, 10))
-        self.frame.grid_rowconfigure(4, weight=1)
+        self.frame.grid_rowconfigure(5, weight=1)
         self.frame.grid_columnconfigure(2, weight=1)
 
         self.follow = tkinter.BooleanVar()
@@ -203,13 +203,26 @@ class PlotControlsView:
                                    pady=(10, 10),
                                    sticky="nsew")
 
+        self.dashboard_button = ctk.CTkButton(
+            master=self.frame,
+            border_width=2,
+            text="Dashboard",
+            command=lambda: plot_button_callback(2),
+        )
+        self.dashboard_button.grid(row=4,
+                                   column=0,
+                                   columnspan=2,
+                                   padx=(10, 10),
+                                   pady=(10, 10),
+                                   sticky="nsew")
+
         self.refresh_button = ctk.CTkButton(
             master=self.frame,
             border_width=2,
             text="Refresh",
             command=refresh_callback,
         )
-        self.refresh_button.grid(row=4,
+        self.refresh_button.grid(row=5,
                                  column=0,
                                  columnspan=2,
                                  padx=(10, 10),
@@ -225,6 +238,7 @@ class PlotControlsView:
         app.interval_label = self.interval_label
         app.button_plot = self.plot_button
         app.button_hist = self.histogram_button
+        app.button_dashboard = self.dashboard_button
         app.button_refresh = self.refresh_button
 
 
@@ -279,8 +293,9 @@ class StatisticsControlsView:
     code created inline.
     """
 
-    def __init__(self, app):
+    def __init__(self, app, statistics_changed_callback=None):
         self.app = app
+        self.statistics_changed_callback = statistics_changed_callback
 
         self.frame = ctk.CTkFrame(app, width=200)
         self.frame.grid(row=1,
@@ -314,9 +329,17 @@ class StatisticsControlsView:
             font=ctk.CTkFont(size=15, weight="bold"),
         )
         self.label.grid(row=0, column=0, padx=10, pady=5, sticky="w")
-        self.mean = ctk.CTkCheckBox(self.statistics_frame, text="Mean")
+        self.mean = ctk.CTkCheckBox(
+            self.statistics_frame,
+            text="Mean",
+            command=statistics_changed_callback,
+        )
         self.mean.grid(row=1, column=0, padx=10, pady=5, sticky="w")
-        self.median = ctk.CTkCheckBox(self.statistics_frame, text="Median")
+        self.median = ctk.CTkCheckBox(
+            self.statistics_frame,
+            text="Median",
+            command=statistics_changed_callback,
+        )
         self.median.grid(row=2, column=0, padx=10, pady=5, sticky="w")
 
         self.time_series_label = ctk.CTkLabel(
@@ -332,6 +355,7 @@ class StatisticsControlsView:
         self.cumulative_average = ctk.CTkCheckBox(
             self.time_series_frame,
             text="Cumulative Average",
+            command=statistics_changed_callback,
         )
         self.cumulative_average.grid(row=1,
                                      column=0,
@@ -339,7 +363,10 @@ class StatisticsControlsView:
                                      pady=5,
                                      sticky="w")
         self.self_correlation_mean = ctk.CTkCheckBox(
-            self.time_series_frame, text="Self-Correlation Mean")
+            self.time_series_frame,
+            text="Self-Correlation Mean",
+            command=statistics_changed_callback,
+        )
         self.self_correlation_mean.grid(row=2,
                                            column=0,
                                            padx=10,
@@ -349,7 +376,7 @@ class StatisticsControlsView:
         self.difference = ctk.CTkCheckBox(
             self.time_series_frame,
             text="Difference (1 - 2)",
-            command=self.__enable_no_data_for_difference,
+            command=self.__difference_command,
         )
         self.difference.grid(row=3,
                              column=0,
@@ -361,8 +388,8 @@ class StatisticsControlsView:
         self.running_average = ctk.CTkCheckBox(
             self.time_series_frame,
             text="Running Average",
-            command=lambda: app.toggle_entry_state(
-                self.running_average, self.window_size, default="10"))
+            command=self.__running_average_command,
+        )
         self.running_average.grid(row=4,
                                   column=0,
                                   padx=10,
@@ -410,3 +437,25 @@ class StatisticsControlsView:
 
         if self.difference.get():
             self.app.plot_main_data.set(True)
+
+    def __difference_command(self):
+        """
+        Apply difference-specific defaults and notify the app.
+        """
+
+        self.__enable_no_data_for_difference()
+        if self.statistics_changed_callback is not None:
+            self.statistics_changed_callback()
+
+    def __running_average_command(self):
+        """
+        Toggle the window entry and notify the app.
+        """
+
+        self.app.toggle_entry_state(
+            self.running_average,
+            self.window_size,
+            default="10",
+        )
+        if self.statistics_changed_callback is not None:
+            self.statistics_changed_callback()

--- a/PQEnalyzer/apps/app_layout.py
+++ b/PQEnalyzer/apps/app_layout.py
@@ -109,15 +109,19 @@ class PlotControlsView:
     """
     Plot command controls.
 
-    This view exposes the ``follow``, ``plot_main_data`` and interval widgets on
-    the app because ``Plot`` reads that state when a plot window is created or
-    refreshed.
+    This view exposes plot state widgets on the app because ``Plot`` reads that
+    state when a plot window is created or refreshed.
     """
 
-    def __init__(self, app, plot_button_callback, refresh_callback):
+    def __init__(
+        self,
+        app,
+        plot_button_callback,
+        auto_refresh_callback,
+    ):
         self.app = app
         self.plot_button_callback = plot_button_callback
-        self.refresh_callback = refresh_callback
+        self.auto_refresh_callback = auto_refresh_callback
 
         self.frame = ctk.CTkFrame(app, width=200)
         self.frame.grid(row=2,
@@ -125,22 +129,23 @@ class PlotControlsView:
                         sticky="nsew",
                         padx=(20, 20),
                         pady=(10, 10))
-        self.frame.grid_rowconfigure(5, weight=1)
+        self.frame.grid_rowconfigure(4, weight=1)
         self.frame.grid_columnconfigure(2, weight=1)
 
-        self.follow = tkinter.BooleanVar()
-        self.follow_checkbox = ctk.CTkCheckBox(
+        self.auto_refresh = tkinter.BooleanVar()
+        self.auto_refresh.set(True)
+        self.auto_refresh_checkbox = ctk.CTkCheckBox(
             master=self.frame,
             border_width=2,
-            text="Follow",
-            variable=self.follow,
-            command=lambda: app.toggle_entry_state(
-                self.follow_checkbox, self.interval_entry, default="1.0"))
-        self.follow_checkbox.grid(row=0,
-                                  column=1,
-                                  padx=(10, 10),
-                                  pady=(10, 10),
-                                  sticky="nsew")
+            text="Auto-Refresh",
+            variable=self.auto_refresh,
+            command=auto_refresh_callback,
+        )
+        self.auto_refresh_checkbox.grid(row=0,
+                                        column=1,
+                                        padx=(10, 10),
+                                        pady=(10, 10),
+                                        sticky="nsew")
 
         self.plot_main_data = tkinter.BooleanVar()
         self.no_data_checkbox = ctk.CTkCheckBox(
@@ -155,27 +160,17 @@ class PlotControlsView:
                                    pady=(10, 10),
                                    sticky="nsew")
 
-        self.interval_entry = ctk.CTkEntry(
+        self.auto_refresh_status_label = ctk.CTkLabel(
             self.frame,
-            width=10,
-            validate="key",
-            validatecommand=(app.register(app.validate_number), "%P"),
+            text="Watching for file changes",
+            anchor="w",
         )
-        self.interval_entry.grid(row=1,
-                                 column=1,
-                                 padx=10,
-                                 pady=5,
-                                 sticky="we")
-        self.interval_entry.configure(state="disabled")
-
-        self.interval_label = ctk.CTkLabel(self.frame,
-                                           text="Interval (s):",
-                                           anchor="w")
-        self.interval_label.grid(row=1,
-                                 column=0,
-                                 padx=10,
-                                 pady=5,
-                                 sticky="w")
+        self.auto_refresh_status_label.grid(row=1,
+                                            column=0,
+                                            columnspan=2,
+                                            padx=10,
+                                            pady=(0, 5),
+                                            sticky="w")
 
         self.plot_button = ctk.CTkButton(
             master=self.frame,
@@ -206,7 +201,7 @@ class PlotControlsView:
         self.dashboard_button = ctk.CTkButton(
             master=self.frame,
             border_width=2,
-            text="Dashboard",
+            text="Live Monitor",
             command=lambda: plot_button_callback(2),
         )
         self.dashboard_button.grid(row=4,
@@ -216,30 +211,15 @@ class PlotControlsView:
                                    pady=(10, 10),
                                    sticky="nsew")
 
-        self.refresh_button = ctk.CTkButton(
-            master=self.frame,
-            border_width=2,
-            text="Refresh",
-            command=refresh_callback,
-        )
-        self.refresh_button.grid(row=5,
-                                 column=0,
-                                 columnspan=2,
-                                 padx=(10, 10),
-                                 pady=(10, 10),
-                                 sticky="nsew")
-
         app.plot_frame = self.frame
-        app.follow = self.follow
-        app.check_follow = self.follow_checkbox
+        app.auto_refresh = self.auto_refresh
+        app.check_auto_refresh = self.auto_refresh_checkbox
         app.plot_main_data = self.plot_main_data
         app.check_nodata = self.no_data_checkbox
-        app.interval = self.interval_entry
-        app.interval_label = self.interval_label
+        app.auto_refresh_status_label = self.auto_refresh_status_label
         app.button_plot = self.plot_button
         app.button_hist = self.histogram_button
         app.button_dashboard = self.dashboard_button
-        app.button_refresh = self.refresh_button
 
 
 class ParameterSelectorView:

--- a/PQEnalyzer/apps/file_watcher.py
+++ b/PQEnalyzer/apps/file_watcher.py
@@ -1,0 +1,105 @@
+"""
+File-change watcher used by the GUI auto-refresh flow.
+"""
+
+from pathlib import Path
+
+from .._logging import get_logger
+
+try:
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+except ImportError:  # pragma: no cover - dependency is installed at runtime
+    FileSystemEventHandler = object
+    Observer = None
+
+
+logger = get_logger(__name__)
+
+
+class _InputFileEventHandler(FileSystemEventHandler):
+    """
+    Forward watchdog events for files currently loaded in the app.
+    """
+
+    def __init__(self, watcher):
+        self.watcher = watcher
+
+    def on_any_event(self, event):
+        """
+        Handle writes, atomically replaced files, and close-write events.
+        """
+
+        if event.event_type not in {"modified", "created", "moved", "closed"}:
+            return
+
+        self.watcher.notify(event)
+
+
+class FileChangeWatcher:
+    """
+    Watch loaded input files and call a callback when one changes.
+    """
+
+    def __init__(self, filenames, callback):
+        self.filenames = {Path(filename).resolve() for filename in filenames}
+        self.callback = callback
+        self.observer = None
+
+    def start(self) -> bool:
+        """
+        Start watching parent folders of the configured files.
+        """
+
+        if Observer is None:
+            logger.warning("Auto-refresh unavailable: watchdog is not installed.")
+            return False
+
+        self.observer = Observer()
+        handler = _InputFileEventHandler(self)
+        for directory in sorted({filename.parent for filename in self.filenames}):
+            self.observer.schedule(handler, str(directory), recursive=False)
+
+        self.observer.start()
+        return True
+
+    def stop(self) -> None:
+        """
+        Stop the background observer if it is running.
+        """
+
+        if self.observer is None:
+            return
+
+        self.observer.stop()
+        self.observer.join(timeout=1.0)
+        self.observer = None
+
+    def notify(self, event) -> None:
+        """
+        Run the callback when a watchdog event belongs to a loaded file.
+        """
+
+        if self.__matches_loaded_file(event):
+            self.callback()
+
+    def __matches_loaded_file(self, event) -> bool:
+        """
+        Return whether an event path is one of the loaded files.
+        """
+
+        if getattr(event, "is_directory", False):
+            return False
+
+        paths = [getattr(event, "src_path", None)]
+        destination = getattr(event, "dest_path", None)
+        if destination:
+            paths.append(destination)
+
+        for path in paths:
+            if path is None:
+                continue
+            if Path(path).resolve() in self.filenames:
+                return True
+
+        return False

--- a/PQEnalyzer/plots/__init__.py
+++ b/PQEnalyzer/plots/__init__.py
@@ -3,5 +3,6 @@ Plot implementations for GUI and terminal rendering.
 """
 
 from .plot_histogram import PlotHistogram
+from .plot_dashboard import PlotDashboard
 from .plot_time import PlotTime
 from .termplot import TermPlot

--- a/PQEnalyzer/plots/options.py
+++ b/PQEnalyzer/plots/options.py
@@ -1,0 +1,38 @@
+"""
+Plot option state shared by GUI plot windows.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PlotOptions:
+    """
+    Snapshot of GUI-controlled plot options for one plot window.
+    """
+
+    mean: bool = False
+    median: bool = False
+    cummulative_average: bool = False
+    self_correlation_mean: bool = False
+    difference: bool = False
+    running_average: bool = False
+    window_size: str = ""
+    plot_main: bool = False
+
+    @classmethod
+    def from_app(cls, app):
+        """
+        Read the current option widgets from the GUI app.
+        """
+
+        return cls(
+            mean=bool(app.mean.get()),
+            median=bool(app.median.get()),
+            cummulative_average=bool(app.cummulative_average.get()),
+            self_correlation_mean=bool(app.self_correlation_mean.get()),
+            difference=bool(app.difference.get()),
+            running_average=bool(app.running_average.get()),
+            window_size=app.window_size.get(),
+            plot_main=bool(app.plot_main_data.get()),
+        )

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -6,7 +6,12 @@ from abc import abstractmethod, ABCMeta
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
+from .._logging import get_logger
+from .options import PlotOptions
 from .theme import apply_figure_theme, apply_matplotlib_theme
+
+
+logger = get_logger(__name__)
 
 
 class Plot(metaclass=ABCMeta):
@@ -48,6 +53,7 @@ class Plot(metaclass=ABCMeta):
 
         self.app = app
         self.reader = app.reader
+        self.options = PlotOptions.from_app(app)
 
         # read parameters from the app
         self.get_app_parameters()
@@ -57,6 +63,8 @@ class Plot(metaclass=ABCMeta):
         self.figure = plt.figure(figsize=(9, 5.5))
         self.ax = self.figure.add_subplot(111)
         self.apply_theme()
+        self.figure.canvas.mpl_connect("button_press_event",
+                                       self.__select_plot)
 
         # set the signal handler
         signal.signal(
@@ -92,16 +100,15 @@ class Plot(metaclass=ABCMeta):
         None
         """
 
-        self.mean = self.app.mean.get()
-        self.median = self.app.median.get()
-        self.cummulative_average = self.app.cummulative_average.get()
-        self.self_correlation_mean = (
-            self.app.self_correlation_mean.get())
-        self.difference = self.app.difference.get()
-        self.running_average = self.app.running_average.get()
-        self.window_size = self.app.window_size.get()
+        self.mean = self.options.mean
+        self.median = self.options.median
+        self.cummulative_average = self.options.cummulative_average
+        self.self_correlation_mean = self.options.self_correlation_mean
+        self.difference = self.options.difference
+        self.running_average = self.options.running_average
+        self.window_size = self.options.window_size
 
-        self.plot_main = self.app.plot_main_data.get()
+        self.plot_main = self.options.plot_main
 
         return None
 
@@ -123,6 +130,7 @@ class Plot(metaclass=ABCMeta):
         """
 
         self.info_parameter = info_parameter
+        self.app.select_plot(self)
 
         # if button is not checked, plot main data
         self.plot_data()
@@ -146,9 +154,15 @@ class Plot(metaclass=ABCMeta):
         """
 
         self.info_parameter = info_parameter
+        self.app.select_plot(self)
 
         def update(frame):
-            self.reader.read_last()
+            try:
+                self.reader.read_last()
+            except Exception as error:  # pylint: disable=broad-exception-caught
+                logger.warning("Plot refresh skipped: %s", error)
+                return []
+
             self.ax.clear()
             self.apply_theme()
             self.plot_data()
@@ -173,18 +187,24 @@ class Plot(metaclass=ABCMeta):
         None
         """
 
-        # Reads the last data
-        self.reader.read_last()
+        try:
+            self.reader.read_last()
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger.warning("Plot refresh skipped: %s", error)
+            return None
 
         self.redraw()
 
         # Show the plot
         plt.show()
 
-    def redraw(self) -> None:
+    def redraw(self, options=None) -> None:
         """
         Redraw an existing plot without reading new file contents.
         """
+
+        if options is not None:
+            self.options = options
 
         # Get the new parameters
         self.get_app_parameters()
@@ -197,6 +217,16 @@ class Plot(metaclass=ABCMeta):
         self.plot_data()
 
         self.figure.canvas.draw_idle()
+
+    def __select_plot(self, event):
+        """
+        Select this plot so GUI controls edit its options.
+        """
+
+        if getattr(event, "inaxes", None) is not self.ax:
+            return
+
+        self.app.select_plot(self)
 
     def plot_data(self) -> None:
         """

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -6,6 +6,7 @@ from abc import abstractmethod, ABCMeta
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
+from ..energy_access import parameter_unit
 from .._logging import get_logger
 from .options import PlotOptions
 from .theme import apply_figure_theme, apply_matplotlib_theme
@@ -59,7 +60,8 @@ class Plot(metaclass=ABCMeta):
         self.get_app_parameters()
 
         # create the plot
-        apply_matplotlib_theme(getattr(self.app, "appearance_mode", None))
+        self.palette = apply_matplotlib_theme(
+            getattr(self.app, "appearance_mode", None))
         self.figure = plt.figure(figsize=(9, 5.5))
         self.ax = self.figure.add_subplot(111)
         self.apply_theme()
@@ -178,7 +180,7 @@ class Plot(metaclass=ABCMeta):
 
         plt.show()
 
-    def refresh(self) -> None:
+    def refresh(self, show=True) -> None:
         """
         Refresh an existing plot with the latest file contents and options.
 
@@ -196,7 +198,8 @@ class Plot(metaclass=ABCMeta):
         self.redraw()
 
         # Show the plot
-        plt.show()
+        if show:
+            plt.show()
 
     def redraw(self, options=None) -> None:
         """
@@ -244,7 +247,7 @@ class Plot(metaclass=ABCMeta):
 
         self.labels(self.info_parameter)
         self.apply_theme()
-        self.figure.tight_layout()
+        self.figure.tight_layout(pad=2.0)
 
         return None
 
@@ -265,12 +268,59 @@ class Plot(metaclass=ABCMeta):
         self.ax.legend(**legend_options)
         return True
 
+    def parameter_axis_label(self, info_parameter: str) -> str:
+        """
+        Return a parameter label including the reader-reported unit.
+        """
+
+        unit = parameter_unit(self.reader.energies[0], info_parameter)
+        return f"{info_parameter} / {unit}"
+
+    def style_single_plot(
+        self,
+        *,
+        title: str,
+        xlabel: str,
+        ylabel: str,
+    ) -> None:
+        """
+        Apply shared single-plot labels and framing.
+        """
+
+        self.set_window_title(title)
+        self.ax.set_title(title, loc="left", pad=10)
+        self.ax.set_xlabel(xlabel)
+        self.ax.set_ylabel(ylabel)
+        self.ax.ticklabel_format(axis="both", style="sci")
+        self.ax.margins(x=0.02, y=0.08)
+
+    def annotation_box(self):
+        """
+        Return a themed rounded label box for latest-value annotations.
+        """
+
+        return dict(
+            boxstyle="round,pad=0.22",
+            facecolor=self.palette["annotation.facecolor"],
+            edgecolor=self.palette["annotation.edgecolor"],
+            alpha=0.88,
+        )
+
+    def set_window_title(self, title: str) -> None:
+        """
+        Name the native matplotlib window when the backend supports it.
+        """
+
+        manager = getattr(self.figure.canvas, "manager", None)
+        if manager is not None and hasattr(manager, "set_window_title"):
+            manager.set_window_title(f"PQEnalyzer - {title}")
+
     def apply_theme(self) -> None:
         """
         Apply the active application appearance mode to this plot.
         """
 
-        apply_figure_theme(
+        self.palette = apply_figure_theme(
             self.figure,
             self.ax,
             getattr(self.app, "appearance_mode", None),

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -1,0 +1,242 @@
+"""
+Live dashboard plotting for all available time-series parameters.
+"""
+
+import math
+import signal
+
+import matplotlib.animation as animation
+import matplotlib.pyplot as plt
+
+from .._logging import get_logger
+from ..energy_access import parameter_unit, series
+from .labels import unique_path_labels
+from .theme import apply_figure_theme, apply_matplotlib_theme
+
+
+logger = get_logger(__name__)
+
+
+class PlotDashboard:
+    """
+    Render a raw overview grid for every parameter in the reader.
+    """
+
+    def __init__(self, app):
+        """
+        Create a dashboard figure for all selectable app parameters.
+        """
+
+        self.app = app
+        self.reader = app.reader
+        self.parameters = list(app.info)
+        self.axis_parameters = {}
+
+        apply_matplotlib_theme(getattr(self.app, "appearance_mode", None))
+        self.figure = plt.figure(figsize=self.__figure_size())
+        self.axes = self.__create_axes()
+        self.ani = None
+
+        signal.signal(
+            signal.SIGINT,
+            lambda signal, frame: self.signal_handler(signal, frame),
+        )
+        self.figure.canvas.mpl_connect("button_press_event",
+                                       self.__button_press_event)
+
+    def signal_handler(self, signal, frame):
+        """
+        Close plot and application windows after SIGINT.
+        """
+
+        plt.close("all")
+        self.app.destroy()
+
+    def simple(self, info_parameter=None) -> None:
+        """
+        Render a static dashboard.
+        """
+
+        self.redraw()
+        plt.show()
+
+    def follow(self, info_parameter=None, interval: float = 1.0) -> None:
+        """
+        Render a live dashboard and refresh it at the configured interval.
+        """
+
+        def update(frame):
+            self.__safe_read_last()
+            self.redraw()
+            return []
+
+        self.redraw()
+        self.ani = animation.FuncAnimation(
+            self.figure,
+            update,
+            blit=True,
+            interval=interval * 1000,
+            cache_frame_data=False,
+        )
+        plt.show()
+
+    def refresh(self) -> None:
+        """
+        Refresh the dashboard while keeping the previous view on read errors.
+        """
+
+        if self.__safe_read_last():
+            self.redraw()
+            plt.show()
+
+    def redraw(self) -> None:
+        """
+        Redraw all raw parameter panels.
+        """
+
+        for ax in self.axes:
+            ax.clear()
+            apply_figure_theme(
+                self.figure,
+                ax,
+                getattr(self.app, "appearance_mode", None),
+            )
+
+        self.axis_parameters = {}
+        labels = unique_path_labels(self.reader.filenames)
+
+        for index, parameter in enumerate(self.parameters):
+            ax = self.axes[index]
+            self.axis_parameters[ax] = parameter
+            self.__plot_parameter(ax, parameter, labels)
+            self.__label_axis(ax, parameter, index)
+
+        for ax in self.axes[len(self.parameters):]:
+            ax.set_visible(False)
+
+        self.__show_legend()
+        self.figure.suptitle("Simulation Dashboard")
+        self.figure.tight_layout(rect=(0, 0, 1, 0.96))
+        self.figure.canvas.draw_idle()
+
+    def __plot_parameter(self, ax, parameter, labels):
+        """
+        Plot one raw parameter panel.
+        """
+
+        for index, energy in enumerate(self.reader.energies):
+            energy_series = series(energy, parameter)
+            ax.plot(
+                energy_series.time,
+                energy_series.values,
+                label=labels[index],
+            )
+            self.__add_latest_value(ax, energy_series.time,
+                                    energy_series.values)
+
+    def __label_axis(self, ax, parameter, index):
+        """
+        Label one dashboard axis compactly.
+        """
+
+        unit = parameter_unit(self.reader.energies[0], parameter)
+        ax.set_title(f"{parameter} / {unit}", fontsize=9)
+        ax.ticklabel_format(axis="both", style="sci")
+        ax.tick_params(labelsize=8)
+
+        ncols = self.__grid_shape()[1]
+        if index >= len(self.axes) - ncols:
+            ax.set_xlabel("Simulation step", fontsize=8)
+
+    def __add_latest_value(self, ax, x, y):
+        """
+        Add a compact latest-value label to one dashboard line.
+        """
+
+        if len(x) == 0 or len(y) == 0:
+            return
+
+        ax.annotate(
+            f"{y[-1]:.3e}",
+            xy=(x[-1], y[-1]),
+            xytext=(4, 0),
+            textcoords="offset points",
+            fontsize=6,
+            horizontalalignment="left",
+            verticalalignment="center",
+            bbox=dict(facecolor="white", alpha=0.45, edgecolor="white"),
+        )
+
+    def __show_legend(self):
+        """
+        Draw one shared legend for the dashboard.
+        """
+
+        for ax in self.axes:
+            handles, labels = ax.get_legend_handles_labels()
+            if labels:
+                self.figure.legend(
+                    handles,
+                    labels,
+                    loc="upper center",
+                    ncol=min(4, len(labels)),
+                    fontsize="small",
+                    frameon=True,
+                )
+                return
+
+        logger.warning("No data to plot.")
+
+    def __safe_read_last(self):
+        """
+        Read the growing output file without closing the dashboard on failures.
+        """
+
+        try:
+            self.reader.read_last()
+        except Exception as error:  # pylint: disable=broad-exception-caught
+            logger.warning("Dashboard refresh skipped: %s", error)
+            return False
+
+        return True
+
+    def __button_press_event(self, event):
+        """
+        Open a focused plot when a dashboard panel is double-clicked.
+        """
+
+        if not getattr(event, "dblclick", False):
+            return
+
+        parameter = self.axis_parameters.get(event.inaxes)
+        if parameter is None:
+            return
+
+        self.app.open_focus_plot(parameter)
+
+    def __create_axes(self):
+        """
+        Create enough axes for all dashboard parameters.
+        """
+
+        nrows, ncols = self.__grid_shape()
+        axes = self.figure.subplots(nrows=nrows, ncols=ncols, squeeze=False)
+        return list(axes.flat)
+
+    def __grid_shape(self):
+        """
+        Return a compact dashboard grid shape.
+        """
+
+        number_of_parameters = max(1, len(self.parameters))
+        ncols = min(3, math.ceil(math.sqrt(number_of_parameters)))
+        nrows = math.ceil(number_of_parameters / ncols)
+        return nrows, ncols
+
+    def __figure_size(self):
+        """
+        Return a readable figure size for the current parameter count.
+        """
+
+        nrows, ncols = self.__grid_shape()
+        return (4.4 * ncols, 2.8 * nrows)

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -11,7 +11,11 @@ import matplotlib.pyplot as plt
 from .._logging import get_logger
 from ..energy_access import parameter_unit, series
 from .labels import unique_path_labels
-from .theme import apply_figure_theme, apply_matplotlib_theme
+from .theme import (
+    apply_figure_theme,
+    apply_matplotlib_theme,
+    palette_for_appearance_mode,
+)
 
 
 logger = get_logger(__name__)
@@ -31,11 +35,15 @@ class PlotDashboard:
         self.reader = app.reader
         self.parameters = list(app.info)
         self.axis_parameters = {}
+        self.selected_parameter = None
+        self.refresh_warning = None
+        self.subtitle_text = None
 
         apply_matplotlib_theme(getattr(self.app, "appearance_mode", None))
         self.figure = plt.figure(figsize=self.__figure_size())
         self.axes = self.__create_axes()
         self.ani = None
+        self.__set_window_title()
 
         signal.signal(
             signal.SIGINT,
@@ -85,9 +93,13 @@ class PlotDashboard:
         Refresh the dashboard while keeping the previous view on read errors.
         """
 
-        if self.__safe_read_last():
-            self.redraw()
-            plt.show()
+        if not self.__safe_read_last():
+            self.__set_title()
+            self.figure.canvas.draw_idle()
+            return None
+
+        self.redraw()
+        plt.show()
 
     def redraw(self) -> None:
         """
@@ -110,13 +122,14 @@ class PlotDashboard:
             self.axis_parameters[ax] = parameter
             self.__plot_parameter(ax, parameter, labels)
             self.__label_axis(ax, parameter, index)
+            self.__style_axis(ax, parameter)
 
         for ax in self.axes[len(self.parameters):]:
             ax.set_visible(False)
 
         self.__show_legend()
-        self.figure.suptitle("Simulation Dashboard")
-        self.figure.tight_layout(rect=(0, 0, 1, 0.96))
+        self.__set_title()
+        self.figure.tight_layout(rect=(0, 0.03, 1, 0.91), h_pad=1.0)
         self.figure.canvas.draw_idle()
 
     def __plot_parameter(self, ax, parameter, labels):
@@ -130,6 +143,8 @@ class PlotDashboard:
                 energy_series.time,
                 energy_series.values,
                 label=labels[index],
+                linewidth=1.45,
+                alpha=0.92,
             )
             self.__add_latest_value(ax, energy_series.time,
                                     energy_series.values)
@@ -140,12 +155,12 @@ class PlotDashboard:
         """
 
         unit = parameter_unit(self.reader.energies[0], parameter)
-        ax.set_title(f"{parameter} / {unit}", fontsize=9)
+        ax.set_title(f"{parameter} / {unit}", fontsize=9, loc="left", pad=6)
         ax.ticklabel_format(axis="both", style="sci")
         ax.tick_params(labelsize=8)
 
-        ncols = self.__grid_shape()[1]
-        if index >= len(self.axes) - ncols:
+        nrows, ncols = self.__grid_shape()
+        if index // ncols == nrows - 1:
             ax.set_xlabel("Simulation step", fontsize=8)
 
     def __add_latest_value(self, ax, x, y):
@@ -161,10 +176,13 @@ class PlotDashboard:
             xy=(x[-1], y[-1]),
             xytext=(4, 0),
             textcoords="offset points",
-            fontsize=6,
+            fontsize=6.5,
             horizontalalignment="left",
             verticalalignment="center",
-            bbox=dict(facecolor="white", alpha=0.45, edgecolor="white"),
+            bbox=dict(boxstyle="round,pad=0.18",
+                      facecolor="white",
+                      alpha=0.5,
+                      edgecolor="white"),
         )
 
     def __show_legend(self):
@@ -178,7 +196,8 @@ class PlotDashboard:
                 self.figure.legend(
                     handles,
                     labels,
-                    loc="upper center",
+                    loc="upper right",
+                    bbox_to_anchor=(0.995, 0.995),
                     ncol=min(4, len(labels)),
                     fontsize="small",
                     frameon=True,
@@ -195,9 +214,11 @@ class PlotDashboard:
         try:
             self.reader.read_last()
         except Exception as error:  # pylint: disable=broad-exception-caught
+            self.refresh_warning = str(error)
             logger.warning("Dashboard refresh skipped: %s", error)
             return False
 
+        self.refresh_warning = None
         return True
 
     def __button_press_event(self, event):
@@ -205,14 +226,17 @@ class PlotDashboard:
         Open a focused plot when a dashboard panel is double-clicked.
         """
 
-        if not getattr(event, "dblclick", False):
-            return
-
         parameter = self.axis_parameters.get(event.inaxes)
         if parameter is None:
             return
 
-        self.app.open_focus_plot(parameter)
+        self.selected_parameter = parameter
+        for ax, axis_parameter in self.axis_parameters.items():
+            self.__style_axis(ax, axis_parameter)
+        self.figure.canvas.draw_idle()
+
+        if getattr(event, "dblclick", False):
+            self.app.open_focus_plot(parameter)
 
     def __create_axes(self):
         """
@@ -240,3 +264,72 @@ class PlotDashboard:
 
         nrows, ncols = self.__grid_shape()
         return (4.4 * ncols, 2.8 * nrows)
+
+    def __style_axis(self, ax, parameter):
+        """
+        Apply dashboard panel styling and selected-panel emphasis.
+        """
+
+        palette = apply_figure_theme(
+            self.figure,
+            ax,
+            getattr(self.app, "appearance_mode", None),
+        )
+        selected = parameter == self.selected_parameter
+        edgecolor = (
+            palette["selected.edgecolor"]
+            if selected
+            else palette["axes.edgecolor"]
+        )
+        linewidth = 2.1 if selected else 1.0
+
+        for spine in ax.spines.values():
+            spine.set_color(edgecolor)
+            spine.set_linewidth(linewidth)
+
+    def __set_title(self):
+        """
+        Set a compact dashboard title with refresh status.
+        """
+
+        palette = palette_for_appearance_mode(
+            getattr(self.app, "appearance_mode", None))
+        if self.refresh_warning:
+            subtitle = f"raw live monitor - refresh skipped: {self.refresh_warning}"
+            color = palette["warning.color"]
+        else:
+            subtitle = "raw live monitor - double-click a panel to focus"
+            color = palette["subtle.text"]
+
+        self.figure.suptitle(
+            "Simulation Dashboard",
+            x=0.012,
+            y=0.995,
+            ha="left",
+            va="top",
+            fontsize=14,
+            fontweight="bold",
+            color=palette["text.color"],
+        )
+        if self.subtitle_text is None:
+            self.subtitle_text = self.figure.text(
+                0.012,
+                0.955,
+                subtitle,
+                ha="left",
+                va="top",
+                fontsize=9,
+                color=color,
+            )
+        else:
+            self.subtitle_text.set_text(subtitle)
+            self.subtitle_text.set_color(color)
+
+    def __set_window_title(self):
+        """
+        Name the native matplotlib window when the backend supports it.
+        """
+
+        manager = getattr(self.figure.canvas, "manager", None)
+        if manager is not None and hasattr(manager, "set_window_title"):
+            manager.set_window_title("PQEnalyzer Dashboard")

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -88,7 +88,7 @@ class PlotDashboard:
         )
         plt.show()
 
-    def refresh(self) -> None:
+    def refresh(self, show=True) -> None:
         """
         Refresh the dashboard while keeping the previous view on read errors.
         """
@@ -99,7 +99,8 @@ class PlotDashboard:
             return None
 
         self.redraw()
-        plt.show()
+        if show:
+            plt.show()
 
     def redraw(self) -> None:
         """
@@ -295,14 +296,22 @@ class PlotDashboard:
         palette = palette_for_appearance_mode(
             getattr(self.app, "appearance_mode", None))
         if self.refresh_warning:
-            subtitle = f"raw live monitor - refresh skipped: {self.refresh_warning}"
+            subtitle = (
+                "watching for file changes - refresh skipped: "
+                f"{self.refresh_warning}"
+            )
             color = palette["warning.color"]
+        elif getattr(self.app, "auto_refresh", None) is not None and (
+            not self.app.auto_refresh.get()
+        ):
+            subtitle = "auto-refresh paused - double-click a panel to focus"
+            color = palette["subtle.text"]
         else:
-            subtitle = "raw live monitor - double-click a panel to focus"
+            subtitle = "watching for file changes - double-click a panel to focus"
             color = palette["subtle.text"]
 
         self.figure.suptitle(
-            "Simulation Dashboard",
+            "Simulation Monitor",
             x=0.012,
             y=0.995,
             ha="left",
@@ -332,4 +341,4 @@ class PlotDashboard:
 
         manager = getattr(self.figure.canvas, "manager", None)
         if manager is not None and hasattr(manager, "set_window_title"):
-            manager.set_window_title("PQEnalyzer Dashboard")
+            manager.set_window_title("PQEnalyzer - Live Monitor")

--- a/PQEnalyzer/plots/plot_histogram.py
+++ b/PQEnalyzer/plots/plot_histogram.py
@@ -5,7 +5,7 @@ from scipy.stats import gaussian_kde
 import numpy as np
 
 from ..statistics import Statistic
-from ..energy_access import concatenate_series, parameter_unit, parameter_values
+from ..energy_access import concatenate_series, parameter_values
 from .._logging import get_logger
 from .labels import unique_path_labels
 from .plot import Plot
@@ -76,7 +76,22 @@ class PlotHistogram(Plot):
             )
 
             y = kde(x)
-            self.ax.plot(x, y, label=f"{labels[i]} KDE")
+            line = self.ax.plot(
+                x,
+                y,
+                label=f"{labels[i]} KDE",
+                linewidth=1.8,
+                alpha=0.95,
+                zorder=3,
+            )[0]
+            self.ax.fill_between(
+                x,
+                y,
+                color=line.get_color(),
+                alpha=0.12,
+                linewidth=0,
+                zorder=2,
+            )
 
         return None
 
@@ -94,14 +109,13 @@ class PlotHistogram(Plot):
         None
         """
 
-        self.ax.set_ylabel("Density")
-
-        self.ax.ticklabel_format(axis="both", style="sci")
-
-        self.ax.set_xlabel(
-            f"{info_parameter} / "
-            f"{parameter_unit(self.reader.energies[0], info_parameter)}"
+        self.style_single_plot(
+            title=f"{info_parameter} distribution",
+            xlabel=self.parameter_axis_label(info_parameter),
+            ylabel="Density",
         )
+        self.ax.margins(x=0.04, y=0.12)
+        self.ax.set_ylim(bottom=0)
 
         _, labels = self.ax.get_legend_handles_labels()
         if not labels:
@@ -132,12 +146,26 @@ class PlotHistogram(Plot):
             # calculate mean and plot
             _, y = Statistic.mean_values(energy_series.time,
                                          energy_series.values)
-            self.ax.axvline(float(y[0]), label="Mean", linestyle="--")
+            self.ax.axvline(
+                float(y[0]),
+                label="Mean",
+                linestyle="--",
+                linewidth=1.35,
+                alpha=0.9,
+                zorder=4,
+            )
 
         if self.median:
             # calculate median and plot
             _, y = Statistic.median_values(energy_series.time,
                                            energy_series.values)
-            self.ax.axvline(float(y[0]), label="Median", linestyle="--")
+            self.ax.axvline(
+                float(y[0]),
+                label="Median",
+                linestyle=":",
+                linewidth=1.6,
+                alpha=0.95,
+                zorder=4,
+            )
 
         return None

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -66,6 +66,8 @@ class PlotTime(Plot):
                 energy_series.time,
                 energy_series.values,
                 label=labels[i],
+                linewidth=1.6,
+                alpha=0.92,
             )
             self.add_value_label(energy_series.time, energy_series.values)
 
@@ -84,6 +86,12 @@ class PlotTime(Plot):
         """
 
         self.ax.set_xlabel("Simulation step")
+        self.ax.set_title(
+            f"{info_parameter} / "
+            f"{parameter_unit(self.reader.energies[0], info_parameter)}",
+            loc="left",
+            pad=10,
+        )
 
         self.ax.ticklabel_format(axis="both", style="sci")
 
@@ -122,7 +130,9 @@ class PlotTime(Plot):
                     delta_series.time,
                     delta_series.values,
                     label="Difference (1 - 2)",
-                    linestyle="--",
+                    linestyle="-",
+                    linewidth=1.9,
+                    alpha=0.95,
                 )
                 self.add_value_label(delta_series.time, delta_series.values)
 
@@ -135,7 +145,14 @@ class PlotTime(Plot):
             # calculate mean and plot
             x, y = Statistic.mean_values(energy_series.time,
                                          energy_series.values)
-            self.ax.plot(x, y, label="Mean", linestyle="--")
+            self.ax.plot(
+                x,
+                y,
+                label="Mean",
+                linestyle="--",
+                linewidth=1.15,
+                alpha=0.85,
+            )
 
             self.add_value_label(x, y)
 
@@ -143,7 +160,14 @@ class PlotTime(Plot):
             # calculate median and plot
             x, y = Statistic.median_values(energy_series.time,
                                            energy_series.values)
-            self.ax.plot(x, y, label="Median", linestyle="--")
+            self.ax.plot(
+                x,
+                y,
+                label="Median",
+                linestyle=":",
+                linewidth=1.35,
+                alpha=0.9,
+            )
 
             self.add_value_label(x, y)
 
@@ -155,7 +179,9 @@ class PlotTime(Plot):
                 x,
                 y,
                 label="Cumulative Average",
-                linestyle="--",
+                linestyle="-.",
+                linewidth=1.45,
+                alpha=0.9,
             )
 
             self.add_value_label(x, y)
@@ -167,7 +193,9 @@ class PlotTime(Plot):
                 x,
                 y,
                 label="Self-Correlation Mean",
-                linestyle="--",
+                linestyle=(0, (2, 2)),
+                linewidth=1.45,
+                alpha=0.9,
             )
 
             self.add_value_label(x, y)
@@ -189,7 +217,9 @@ class PlotTime(Plot):
                 x,
                 y,
                 label="Running Average (" + str(window_size_int) + ")",
-                linestyle="--",
+                linestyle="-",
+                linewidth=2.0,
+                alpha=0.95,
             )
 
             self.add_value_label(x, y)
@@ -235,7 +265,10 @@ class PlotTime(Plot):
             fontsize=8,
             horizontalalignment="left",
             verticalalignment="center",
-            bbox=dict(facecolor="white", alpha=0.5, edgecolor="white"),
+            bbox=dict(boxstyle="round,pad=0.2",
+                      facecolor="white",
+                      alpha=0.55,
+                      edgecolor="white"),
         )
 
         return None

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -6,7 +6,6 @@ from ..statistics import Statistic
 from ..energy_access import (
     concatenate_series,
     difference_series,
-    parameter_unit,
     series,
 )
 from .._logging import get_logger
@@ -68,6 +67,7 @@ class PlotTime(Plot):
                 label=labels[i],
                 linewidth=1.6,
                 alpha=0.92,
+                zorder=2,
             )
             self.add_value_label(energy_series.time, energy_series.values)
 
@@ -85,19 +85,10 @@ class PlotTime(Plot):
         None
         """
 
-        self.ax.set_xlabel("Simulation step")
-        self.ax.set_title(
-            f"{info_parameter} / "
-            f"{parameter_unit(self.reader.energies[0], info_parameter)}",
-            loc="left",
-            pad=10,
-        )
-
-        self.ax.ticklabel_format(axis="both", style="sci")
-
-        self.ax.set_ylabel(
-            f"{info_parameter} / "
-            f"{parameter_unit(self.reader.energies[0], info_parameter)}"
+        self.style_single_plot(
+            title=f"{info_parameter} time series",
+            xlabel="Simulation step",
+            ylabel=self.parameter_axis_label(info_parameter),
         )
 
         if not self.show_legend(loc="best"):
@@ -133,6 +124,7 @@ class PlotTime(Plot):
                     linestyle="-",
                     linewidth=1.9,
                     alpha=0.95,
+                    zorder=4,
                 )
                 self.add_value_label(delta_series.time, delta_series.values)
 
@@ -152,6 +144,7 @@ class PlotTime(Plot):
                 linestyle="--",
                 linewidth=1.15,
                 alpha=0.85,
+                zorder=3,
             )
 
             self.add_value_label(x, y)
@@ -167,6 +160,7 @@ class PlotTime(Plot):
                 linestyle=":",
                 linewidth=1.35,
                 alpha=0.9,
+                zorder=3,
             )
 
             self.add_value_label(x, y)
@@ -182,6 +176,7 @@ class PlotTime(Plot):
                 linestyle="-.",
                 linewidth=1.45,
                 alpha=0.9,
+                zorder=3,
             )
 
             self.add_value_label(x, y)
@@ -196,6 +191,7 @@ class PlotTime(Plot):
                 linestyle=(0, (2, 2)),
                 linewidth=1.45,
                 alpha=0.9,
+                zorder=3,
             )
 
             self.add_value_label(x, y)
@@ -220,6 +216,7 @@ class PlotTime(Plot):
                 linestyle="-",
                 linewidth=2.0,
                 alpha=0.95,
+                zorder=4,
             )
 
             self.add_value_label(x, y)
@@ -265,10 +262,8 @@ class PlotTime(Plot):
             fontsize=8,
             horizontalalignment="left",
             verticalalignment="center",
-            bbox=dict(boxstyle="round,pad=0.2",
-                      facecolor="white",
-                      alpha=0.55,
-                      edgecolor="white"),
+            bbox=self.annotation_box(),
+            zorder=5,
         )
 
         return None

--- a/PQEnalyzer/plots/theme.py
+++ b/PQEnalyzer/plots/theme.py
@@ -130,7 +130,13 @@ def apply_figure_theme(figure, axes, appearance_mode=None):
     axes.tick_params(colors=palette["tick.color"])
     axes.xaxis.label.set_color(palette["axes.labelcolor"])
     axes.yaxis.label.set_color(palette["axes.labelcolor"])
-    axes.title.set_color(palette["text.color"])
+    for title in (
+        axes.title,
+        getattr(axes, "_left_title", None),
+        getattr(axes, "_right_title", None),
+    ):
+        if title is not None:
+            title.set_color(palette["text.color"])
 
     for spine in axes.spines.values():
         spine.set_color(palette["axes.edgecolor"])

--- a/PQEnalyzer/plots/theme.py
+++ b/PQEnalyzer/plots/theme.py
@@ -8,33 +8,57 @@ from cycler import cycler
 
 
 LIGHT_PALETTE = {
-    "figure.facecolor": "#f8fafc",
+    "figure.facecolor": "#f4f7fb",
     "axes.facecolor": "#ffffff",
-    "axes.edgecolor": "#64748b",
+    "axes.edgecolor": "#cbd5e1",
     "axes.labelcolor": "#0f172a",
     "text.color": "#0f172a",
-    "tick.color": "#334155",
-    "grid.color": "#cbd5e1",
+    "subtle.text": "#64748b",
+    "tick.color": "#475569",
+    "grid.color": "#e2e8f0",
     "legend.facecolor": "#ffffff",
     "legend.edgecolor": "#cbd5e1",
     "annotation.facecolor": "#f1f5f9",
     "annotation.edgecolor": "#cbd5e1",
-    "colors": ["#2563eb", "#e11d48", "#059669", "#7c3aed", "#d97706"],
+    "selected.edgecolor": "#2563eb",
+    "warning.color": "#b45309",
+    "colors": [
+        "#2563eb",
+        "#e11d48",
+        "#059669",
+        "#7c3aed",
+        "#d97706",
+        "#0891b2",
+        "#be123c",
+        "#16a34a",
+    ],
 }
 
 DARK_PALETTE = {
-    "figure.facecolor": "#111827",
-    "axes.facecolor": "#0f172a",
-    "axes.edgecolor": "#94a3b8",
+    "figure.facecolor": "#0b1120",
+    "axes.facecolor": "#111827",
+    "axes.edgecolor": "#334155",
     "axes.labelcolor": "#e5e7eb",
     "text.color": "#e5e7eb",
+    "subtle.text": "#94a3b8",
     "tick.color": "#cbd5e1",
-    "grid.color": "#334155",
-    "legend.facecolor": "#111827",
+    "grid.color": "#1e293b",
+    "legend.facecolor": "#0f172a",
     "legend.edgecolor": "#475569",
-    "annotation.facecolor": "#1e293b",
+    "annotation.facecolor": "#0f172a",
     "annotation.edgecolor": "#475569",
-    "colors": ["#60a5fa", "#fb7185", "#34d399", "#c084fc", "#fbbf24"],
+    "selected.edgecolor": "#60a5fa",
+    "warning.color": "#fbbf24",
+    "colors": [
+        "#60a5fa",
+        "#fb7185",
+        "#34d399",
+        "#c084fc",
+        "#fbbf24",
+        "#22d3ee",
+        "#f43f5e",
+        "#4ade80",
+    ],
 }
 
 
@@ -75,11 +99,15 @@ def apply_matplotlib_theme(appearance_mode=None):
         "axes.labelcolor": palette["axes.labelcolor"],
         "axes.grid": True,
         "axes.prop_cycle": cycler(color=palette["colors"]),
+        "axes.titleweight": "semibold",
+        "axes.titlesize": "medium",
+        "lines.linewidth": 1.45,
+        "lines.solid_capstyle": "round",
         "text.color": palette["text.color"],
         "xtick.color": palette["tick.color"],
         "ytick.color": palette["tick.color"],
         "grid.color": palette["grid.color"],
-        "grid.alpha": 0.35,
+        "grid.alpha": 0.55,
         "legend.facecolor": palette["legend.facecolor"],
         "legend.edgecolor": palette["legend.edgecolor"],
         "legend.framealpha": 0.95,
@@ -98,7 +126,7 @@ def apply_figure_theme(figure, axes, appearance_mode=None):
 
     figure.patch.set_facecolor(palette["figure.facecolor"])
     axes.set_facecolor(palette["axes.facecolor"])
-    axes.grid(True, color=palette["grid.color"], alpha=0.35)
+    axes.grid(True, color=palette["grid.color"], alpha=0.55, linewidth=0.8)
     axes.tick_params(colors=palette["tick.color"])
     axes.xaxis.label.set_color(palette["axes.labelcolor"])
     axes.yaxis.label.set_color(palette["axes.labelcolor"])
@@ -106,6 +134,7 @@ def apply_figure_theme(figure, axes, appearance_mode=None):
 
     for spine in axes.spines.values():
         spine.set_color(palette["axes.edgecolor"])
+        spine.set_linewidth(1.0)
 
     legend = axes.get_legend()
     if legend is not None:

--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ pqenalyzer md-01.en md-02.en md-03.en
 For two aligned runs, the GUI and terminal mode can plot a pointwise difference
 as the first input file minus the second input file.
 
-In GUI mode, `Dashboard` opens a live raw overview with one panel per
-parameter. Double-click a dashboard panel to open a focused plot for that
+In GUI mode, `Live Monitor` opens a raw overview with one panel per parameter.
+`Auto-Refresh` watches the loaded file for changes and redraws open plots when
+new simulation output is written. Disable `Auto-Refresh` to pause file
+watching. Double-click a monitor panel to open a focused plot for that
 parameter. Statistics and time-series overlay controls apply to the selected
-focused plot, while the dashboard stays raw for simulation monitoring.
+focused plot, while the monitor stays raw for simulation monitoring.
 
 ## Input Files
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ pqenalyzer md-01.en md-02.en md-03.en
 For two aligned runs, the GUI and terminal mode can plot a pointwise difference
 as the first input file minus the second input file.
 
+In GUI mode, `Dashboard` opens a live raw overview with one panel per
+parameter. Double-click a dashboard panel to open a focused plot for that
+parameter. Statistics and time-series overlay controls apply to the selected
+focused plot, while the dashboard stays raw for simulation monitoring.
+
 ## Input Files
 
 PQEnalyzer reads energy output through

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "scipy",
     "plotext",
     "InquirerPy",
+    "watchdog",
 ]
 
 [project.optional-dependencies]

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -103,14 +103,18 @@ def reset_dummy_plots():
     DummyPlot.instances = []
 
 
-def make_app(follow=False, interval=""):
+def make_app(auto_refresh=True):
     app = object.__new__(app_module.App)
-    app.follow = FakeFlag(follow)
-    app.interval = FakeEntry(interval)
+    app.auto_refresh = FakeFlag(auto_refresh)
+    app.reader = SimpleNamespace(filenames=["/tmp/md.en"])
     app.list_of_plots = []
     app.selected_plot = None
     app._App__syncing_plot_controls = False
+    app._App__file_watcher = None
+    app._App__auto_refresh_after_id = None
     app._App__selected_info = "TEMPERATURE"
+    app.after = lambda delay, callback: "after-id"
+    app.after_cancel = lambda after_id: None
     return app
 
 
@@ -262,10 +266,18 @@ def test_plot_controls_view_exposes_dashboard_button(monkeypatch):
     monkeypatch.setattr(app_layout.tkinter, "BooleanVar",
                         lambda: FakeFlag(False))
 
-    view = app_layout.PlotControlsView(app, lambda event: event, lambda: None)
+    view = app_layout.PlotControlsView(
+        app,
+        lambda event: event,
+        lambda: None,
+    )
 
     assert app.button_dashboard is view.dashboard_button
-    assert app.button_dashboard.kwargs["text"] == "Dashboard"
+    assert app.button_dashboard.kwargs["text"] == "Live Monitor"
+    assert app.check_auto_refresh is view.auto_refresh_checkbox
+    assert app.check_auto_refresh.kwargs["text"] == "Auto-Refresh"
+    assert app.auto_refresh.value is True
+    assert not hasattr(app, "button_refresh")
 
 
 def test_statistics_controls_view_exposes_plot_state_attributes(monkeypatch):
@@ -369,29 +381,18 @@ def test_statistics_control_callback_runs_after_difference_default(
     assert calls == ["run"]
 
 
-def test_plot_button_rejects_invalid_follow_interval(monkeypatch, caplog):
-    app = make_app(follow=True, interval="0")
-    monkeypatch.setattr(app_module, "PlotTime", DummyPlot)
-
-    app_module.App._App__plot_button_event(app, 0)
-
-    assert app.list_of_plots == []
-    assert DummyPlot.instances == []
-    assert "Interval must be greater than zero" in caplog.text
-
-
-def test_plot_button_passes_valid_follow_interval(monkeypatch):
-    app = make_app(follow=True, interval="2.5")
+def test_plot_button_runs_simple_time_plot_with_auto_refresh(monkeypatch):
+    app = make_app(auto_refresh=True)
     monkeypatch.setattr(app_module, "PlotTime", DummyPlot)
 
     app_module.App._App__plot_button_event(app, 0)
 
     assert app.list_of_plots == DummyPlot.instances
-    assert DummyPlot.instances[0].calls == [("follow", "TEMPERATURE", 2.5)]
+    assert DummyPlot.instances[0].calls == [("simple", "TEMPERATURE")]
 
 
 def test_plot_button_runs_simple_histogram(monkeypatch):
-    app = make_app(follow=False)
+    app = make_app(auto_refresh=False)
     monkeypatch.setattr(app_module, "PlotHistogram", DummyPlot)
 
     app_module.App._App__plot_button_event(app, 1)
@@ -401,7 +402,7 @@ def test_plot_button_runs_simple_histogram(monkeypatch):
 
 
 def test_plot_button_runs_dashboard(monkeypatch):
-    app = make_app(follow=False)
+    app = make_app(auto_refresh=False)
     monkeypatch.setattr(app_module, "PlotDashboard", DummyPlot)
 
     app_module.App._App__plot_button_event(app, 2)
@@ -539,8 +540,9 @@ def test_refresh_applies_controls_to_selected_plot(monkeypatch):
             self.options = PlotOptions()
             self.refreshed = False
 
-        def refresh(self):
+        def refresh(self, show=True):
             self.refreshed = True
+            self.show = show
 
     plot = SelectedPlot()
     app.selected_plot = plot
@@ -550,8 +552,106 @@ def test_refresh_applies_controls_to_selected_plot(monkeypatch):
     app_module.App._App__refresh_plots(app)
 
     assert plot.refreshed is True
+    assert plot.show is True
     assert plot.options.running_average is True
     assert plot.options.window_size == "15"
+
+
+def test_auto_refresh_control_starts_and_stops_file_watcher(monkeypatch):
+    app = make_app(auto_refresh=True)
+    status = FakeWidget()
+    app.auto_refresh_status_label = status
+    created_watchers = []
+
+    class FakeWatcher:
+
+        def __init__(self, filenames, callback):
+            self.filenames = filenames
+            self.callback = callback
+            self.started = False
+            self.stopped = False
+            created_watchers.append(self)
+
+        def start(self):
+            self.started = True
+            return True
+
+        def stop(self):
+            self.stopped = True
+
+    monkeypatch.setattr(app_module, "FileChangeWatcher", FakeWatcher)
+
+    app_module.App._App__auto_refresh_control_event(app)
+
+    assert created_watchers[0].filenames == ["/tmp/md.en"]
+    assert created_watchers[0].started is True
+    assert status.configure_kwargs["text"] == "Watching for file changes"
+
+    app.auto_refresh.set(False)
+    app_module.App._App__auto_refresh_control_event(app)
+
+    assert created_watchers[0].stopped is True
+    assert app._App__file_watcher is None
+    assert status.configure_kwargs["text"] == "Auto-refresh paused"
+
+
+def test_auto_refresh_control_disables_toggle_when_watcher_unavailable(
+        monkeypatch):
+    app = make_app(auto_refresh=True)
+    status = FakeWidget()
+    app.auto_refresh_status_label = status
+
+    class FakeWatcher:
+
+        def __init__(self, filenames, callback):
+            pass
+
+        def start(self):
+            return False
+
+    monkeypatch.setattr(app_module, "FileChangeWatcher", FakeWatcher)
+
+    app_module.App._App__auto_refresh_control_event(app)
+
+    assert app.auto_refresh.value is False
+    assert status.configure_kwargs["text"] == "Auto-refresh unavailable"
+
+
+def test_auto_refresh_debounces_file_events():
+    app = make_app(auto_refresh=True)
+    calls = []
+
+    app._App__auto_refresh_after_id = "old"
+    app.after_cancel = lambda after_id: calls.append(("cancel", after_id))
+    app.after = lambda delay, callback: calls.append(
+        ("after", delay, callback.__name__)) or "new"
+
+    app_module.App._App__schedule_auto_refresh(app)
+
+    assert app._App__auto_refresh_after_id == "new"
+    assert calls == [
+        ("cancel", "old"),
+        ("after", 250, "__auto_refresh_plots"),
+    ]
+
+
+def test_auto_refresh_redraws_open_plots_without_show(monkeypatch):
+    app = make_app(auto_refresh=True)
+    calls = []
+
+    class OpenPlot:
+        figure = SimpleNamespace(number=1)
+
+        def refresh(self, show=True):
+            calls.append(show)
+
+    app.list_of_plots = [OpenPlot()]
+    monkeypatch.setattr(app_module.plt, "get_fignums", lambda: [1])
+
+    app_module.App._App__auto_refresh_plots(app)
+
+    assert app._App__auto_refresh_after_id is None
+    assert calls == [False]
 
 
 def test_terminal_app_passes_difference_choice_for_two_files(monkeypatch):

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -7,6 +7,7 @@ import pytest
 from PQEnalyzer.apps import app as app_module
 from PQEnalyzer.apps import app_layout
 from PQEnalyzer.apps import termapp as termapp_module
+from PQEnalyzer.plots.options import PlotOptions
 
 
 class FakeFlag:
@@ -16,6 +17,15 @@ class FakeFlag:
 
     def get(self):
         return self.value
+
+    def set(self, value):
+        self.value = value
+
+    def select(self):
+        self.value = True
+
+    def deselect(self):
+        self.value = False
 
 
 class FakeEntry:
@@ -60,6 +70,7 @@ class FakeWidget:
         self.grid_calls = []
         self.configured_rows = []
         self.configured_columns = []
+        self.value = False
 
     def grid(self, *args, **kwargs):
         self.grid_calls.append((args, kwargs))
@@ -72,6 +83,15 @@ class FakeWidget:
 
     def set(self, value):
         self.value = value
+
+    def get(self):
+        return self.value
+
+    def select(self):
+        self.value = True
+
+    def deselect(self):
+        self.value = False
 
     def configure(self, *args, **kwargs):
         self.configure_args = args
@@ -88,6 +108,8 @@ def make_app(follow=False, interval=""):
     app.follow = FakeFlag(follow)
     app.interval = FakeEntry(interval)
     app.list_of_plots = []
+    app.selected_plot = None
+    app._App__syncing_plot_controls = False
     app._App__selected_info = "TEMPERATURE"
     return app
 
@@ -225,6 +247,27 @@ def test_parameter_selector_view_sets_initial_selection(monkeypatch):
     assert app.info_optionmenu.kwargs["command"] == selected.append
 
 
+def test_plot_controls_view_exposes_dashboard_button(monkeypatch):
+    app = SimpleNamespace(
+        register=lambda callback: callback,
+        validate_number=lambda value: True,
+        toggle_entry_state=lambda event, entry, default="": None,
+    )
+
+    monkeypatch.setattr(app_layout.ctk, "CTkFrame", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkCheckBox", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkEntry", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkLabel", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkButton", FakeWidget)
+    monkeypatch.setattr(app_layout.tkinter, "BooleanVar",
+                        lambda: FakeFlag(False))
+
+    view = app_layout.PlotControlsView(app, lambda event: event, lambda: None)
+
+    assert app.button_dashboard is view.dashboard_button
+    assert app.button_dashboard.kwargs["text"] == "Dashboard"
+
+
 def test_statistics_controls_view_exposes_plot_state_attributes(monkeypatch):
     app = SimpleNamespace(
         register=lambda callback: callback,
@@ -291,6 +334,41 @@ def test_difference_checkbox_enables_no_data(monkeypatch):
     assert app.plot_main_data.value is True
 
 
+def test_statistics_control_callback_runs_after_difference_default(
+        monkeypatch):
+    calls = []
+
+    class FakeBoolean:
+
+        def __init__(self):
+            self.value = False
+
+        def set(self, value):
+            self.value = value
+
+    app = SimpleNamespace(
+        register=lambda callback: callback,
+        validate_number=lambda value: True,
+        toggle_entry_state=lambda event, entry, default="": None,
+        plot_main_data=FakeBoolean(),
+    )
+
+    monkeypatch.setattr(app_layout.ctk, "CTkFrame", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkLabel", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkCheckBox", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkEntry", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkFont",
+                        lambda *args, **kwargs: ("font", args, kwargs))
+
+    view = app_layout.StatisticsControlsView(app, lambda: calls.append("run"))
+    view.difference.value = True
+
+    view.difference.kwargs["command"]()
+
+    assert app.plot_main_data.value is True
+    assert calls == ["run"]
+
+
 def test_plot_button_rejects_invalid_follow_interval(monkeypatch, caplog):
     app = make_app(follow=True, interval="0")
     monkeypatch.setattr(app_module, "PlotTime", DummyPlot)
@@ -320,6 +398,17 @@ def test_plot_button_runs_simple_histogram(monkeypatch):
 
     assert app.list_of_plots == DummyPlot.instances
     assert DummyPlot.instances[0].calls == [("simple", "TEMPERATURE")]
+
+
+def test_plot_button_runs_dashboard(monkeypatch):
+    app = make_app(follow=False)
+    monkeypatch.setattr(app_module, "PlotDashboard", DummyPlot)
+
+    app_module.App._App__plot_button_event(app, 2)
+
+    assert app.list_of_plots == DummyPlot.instances
+    assert DummyPlot.instances[0].calls == [("simple", None)]
+    assert app.selected_plot is None
 
 
 def test_plot_button_rejects_unknown_event():
@@ -361,6 +450,108 @@ def test_change_appearance_mode_updates_matplotlib_and_open_plots(monkeypatch):
     assert app.appearance_mode == "Dark"
     assert app.list_of_plots == [open_plot]
     assert calls == [("ctk", "Dark"), ("mpl", "Dark"), ("redraw", 1)]
+
+
+def test_select_plot_syncs_plot_options_to_controls(monkeypatch):
+    app = make_app()
+    app.mean = FakeFlag(False)
+    app.median = FakeFlag(False)
+    app.cummulative_average = FakeFlag(False)
+    app.self_correlation_mean = FakeFlag(False)
+    app.difference = FakeFlag(False)
+    app.running_average = FakeFlag(False)
+    app.plot_main_data = FakeFlag(False)
+    app.window_size = FakeEntry("")
+
+    plot = SimpleNamespace(
+        figure=SimpleNamespace(number=1),
+        options=PlotOptions(
+            mean=True,
+            median=True,
+            cummulative_average=True,
+            self_correlation_mean=True,
+            difference=True,
+            running_average=True,
+            window_size="25",
+            plot_main=True,
+        ),
+    )
+    monkeypatch.setattr(app_module.plt, "get_fignums", lambda: [1])
+
+    app_module.App.select_plot(app, plot)
+
+    assert app.selected_plot is plot
+    assert app.mean.value is True
+    assert app.median.value is True
+    assert app.cummulative_average.value is True
+    assert app.self_correlation_mean.value is True
+    assert app.difference.value is True
+    assert app.running_average.value is True
+    assert app.plot_main_data.value is True
+    assert app.window_size.value == "25"
+    assert app.window_size.state == "normal"
+
+
+def test_statistics_controls_redraw_selected_plot(monkeypatch):
+    app = make_app()
+    app.mean = FakeFlag(True)
+    app.median = FakeFlag(False)
+    app.cummulative_average = FakeFlag(False)
+    app.self_correlation_mean = FakeFlag(False)
+    app.difference = FakeFlag(False)
+    app.running_average = FakeFlag(True)
+    app.plot_main_data = FakeFlag(False)
+    app.window_size = FakeEntry("5")
+    calls = []
+
+    class SelectedPlot:
+        figure = SimpleNamespace(number=1)
+
+        def redraw(self, options=None):
+            calls.append(options)
+
+    app.selected_plot = SelectedPlot()
+    monkeypatch.setattr(app_module.plt, "get_fignums", lambda: [1])
+
+    app_module.App._App__statistics_control_event(app)
+
+    assert len(calls) == 1
+    assert calls[0].mean is True
+    assert calls[0].running_average is True
+    assert calls[0].window_size == "5"
+
+
+def test_refresh_applies_controls_to_selected_plot(monkeypatch):
+    app = make_app()
+    app.mean = FakeFlag(False)
+    app.median = FakeFlag(False)
+    app.cummulative_average = FakeFlag(False)
+    app.self_correlation_mean = FakeFlag(False)
+    app.difference = FakeFlag(False)
+    app.running_average = FakeFlag(True)
+    app.plot_main_data = FakeFlag(False)
+    app.window_size = FakeEntry("15")
+
+    class SelectedPlot:
+
+        def __init__(self):
+            self.figure = SimpleNamespace(number=1)
+            self.options = PlotOptions()
+            self.refreshed = False
+
+        def refresh(self):
+            self.refreshed = True
+
+    plot = SelectedPlot()
+    app.selected_plot = plot
+    app.list_of_plots = [plot]
+    monkeypatch.setattr(app_module.plt, "get_fignums", lambda: [1])
+
+    app_module.App._App__refresh_plots(app)
+
+    assert plot.refreshed is True
+    assert plot.options.running_average is True
+    assert plot.options.window_size == "15"
 
 
 def test_terminal_app_passes_difference_choice_for_two_files(monkeypatch):

--- a/tests/apps/test_file_watcher.py
+++ b/tests/apps/test_file_watcher.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from PQEnalyzer.apps import file_watcher
+from PQEnalyzer.apps.file_watcher import FileChangeWatcher
+
+
+def test_file_change_watcher_notifies_for_loaded_file(tmp_path):
+    energy_file = tmp_path / "run.en"
+    calls = []
+    watcher = FileChangeWatcher([energy_file], lambda: calls.append("run"))
+    event = SimpleNamespace(
+        event_type="modified",
+        is_directory=False,
+        src_path=str(energy_file),
+    )
+
+    watcher.notify(event)
+
+    assert calls == ["run"]
+
+
+def test_file_change_watcher_notifies_for_moved_destination(tmp_path):
+    energy_file = tmp_path / "run.en"
+    replacement = tmp_path / ".run.en.tmp"
+    calls = []
+    watcher = FileChangeWatcher([energy_file], lambda: calls.append("run"))
+    event = SimpleNamespace(
+        event_type="moved",
+        is_directory=False,
+        src_path=str(replacement),
+        dest_path=str(energy_file),
+    )
+
+    watcher.notify(event)
+
+    assert calls == ["run"]
+
+
+def test_file_change_watcher_ignores_directories_and_unloaded_files(tmp_path):
+    energy_file = tmp_path / "run.en"
+    other_file = tmp_path / "other.en"
+    calls = []
+    watcher = FileChangeWatcher([energy_file], lambda: calls.append("run"))
+
+    watcher.notify(
+        SimpleNamespace(is_directory=True, src_path=str(energy_file)))
+    watcher.notify(
+        SimpleNamespace(is_directory=False, src_path=str(other_file)))
+
+    assert calls == []
+
+
+def test_file_change_watcher_schedules_unique_parent_directories(
+        tmp_path, monkeypatch):
+    first = tmp_path / "a" / "first.en"
+    second = tmp_path / "a" / "second.en"
+    third = tmp_path / "b" / "third.en"
+    scheduled = []
+
+    class FakeObserver:
+
+        def schedule(self, handler, directory, recursive):
+            scheduled.append((handler, directory, recursive))
+
+        def start(self):
+            scheduled.append(("start", None, None))
+
+        def stop(self):
+            scheduled.append(("stop", None, None))
+
+        def join(self, timeout=None):
+            scheduled.append(("join", timeout, None))
+
+    monkeypatch.setattr(file_watcher, "Observer", FakeObserver)
+
+    watcher = FileChangeWatcher([first, second, third], lambda: None)
+
+    assert watcher.start() is True
+    watcher.stop()
+
+    assert [entry[1] for entry in scheduled[:2]] == [
+        str(tmp_path / "a"),
+        str(tmp_path / "b"),
+    ]
+    assert scheduled[0][2] is False
+    assert scheduled[1][2] is False
+    assert scheduled[2] == ("start", None, None)
+    assert scheduled[-2:] == [("stop", None, None), ("join", 1.0, None)]
+
+
+def test_file_change_watcher_reports_unavailable_observer(monkeypatch):
+    monkeypatch.setattr(file_watcher, "Observer", None)
+
+    watcher = FileChangeWatcher(["run.en"], lambda: None)
+
+    assert watcher.start() is False

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -125,6 +125,7 @@ def test_histogram_skips_constant_series_and_plots_remaining_data(caplog):
     plot.main_data("PARAMETER")
 
     assert plot.ax.get_legend_handles_labels()[1] == ["series-1.en KDE"]
+    assert len(plot.ax.collections) == 1
     assert "Data zero. No histogram available." in caplog.text
 
 
@@ -141,6 +142,7 @@ def test_histogram_disambiguates_duplicate_filenames():
         "run-a/md.en KDE",
         "run-b/md.en KDE",
     ]
+    assert len(plot.ax.collections) == 2
 
 
 def test_histogram_statistics_draw_single_mean_and_median_lines():
@@ -151,7 +153,21 @@ def test_histogram_statistics_draw_single_mean_and_median_lines():
 
     assert plot.ax.get_legend_handles_labels()[1] == ["Mean", "Median"]
     assert len(plot.ax.lines) == 2
-    assert all(line.get_linestyle() == "--" for line in plot.ax.lines)
+    assert [line.get_linestyle() for line in plot.ax.lines] == ["--", ":"]
+    assert [line.get_zorder() for line in plot.ax.lines] == [4, 4]
+
+
+def test_histogram_labels_use_distribution_title_and_density_axis():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])])
+    plot = PlotHistogram(app)
+
+    plot.main_data("PARAMETER")
+    plot.labels("PARAMETER")
+
+    assert plot.ax.get_title(loc="left") == "PARAMETER distribution"
+    assert plot.ax.get_xlabel() == "PARAMETER / unit"
+    assert plot.ax.get_ylabel() == "Density"
+    assert plot.ax.get_ylim()[0] == 0
 
 
 def test_time_main_data_uses_readable_filenames_and_value_labels():
@@ -161,8 +177,23 @@ def test_time_main_data_uses_readable_filenames_and_value_labels():
     plot.main_data("PARAMETER")
 
     assert plot.ax.get_legend_handles_labels()[1] == ["series-0.en"]
+    assert plot.ax.lines[0].get_linewidth() == 1.6
+    assert plot.ax.lines[0].get_alpha() == 0.92
+    assert plot.ax.lines[0].get_zorder() == 2
     assert len(plot.ax.texts) == 1
     assert plot.ax.texts[0].get_text() == "4.000e+00"
+
+
+def test_time_labels_use_time_series_title_and_parameter_axis():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])])
+    plot = PlotTime(app)
+
+    plot.main_data("PARAMETER")
+    plot.labels("PARAMETER")
+
+    assert plot.ax.get_title(loc="left") == "PARAMETER time series"
+    assert plot.ax.get_xlabel() == "Simulation step"
+    assert plot.ax.get_ylabel() == "PARAMETER / unit"
 
 
 def test_time_main_data_disambiguates_duplicate_filenames():
@@ -212,6 +243,13 @@ def test_time_statistics_draw_expected_overlay_series():
         "Self-Correlation Mean",
         "Running Average (2)",
     ]
+    assert [line.get_linestyle() for line in plot.ax.lines[:3]] == [
+        "--",
+        ":",
+        "-.",
+    ]
+    assert plot.ax.lines[-1].get_linestyle() == "-"
+    assert plot.ax.lines[-1].get_zorder() == 4
 
 
 def test_time_difference_subtracts_two_aligned_series():

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -1,6 +1,8 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from types import SimpleNamespace
 
+from PQEnalyzer.plots.plot_dashboard import PlotDashboard
 from PQEnalyzer.plots.plot_histogram import PlotHistogram
 from PQEnalyzer.plots.plot_time import PlotTime
 
@@ -12,6 +14,9 @@ class FakeFlag:
 
     def get(self):
         return self.value
+
+    def set(self, value):
+        self.value = value
 
 
 class FakeEntry:
@@ -32,6 +37,27 @@ class FakeEnergy:
         self.simulation_time = np.arange(1, len(values) + 1)
 
 
+class FakeDashboardEnergy:
+
+    def __init__(self):
+        self.info = {
+            "SIMULATION-TIME": "SIMULATION-TIME",
+            "TEMPERATURE": "TEMPERATURE",
+            "PRESSURE": "PRESSURE",
+        }
+        self.units = {
+            "SIMULATION-TIME": "step",
+            "TEMPERATURE": "K",
+            "PRESSURE": "bar",
+        }
+        self.data = {
+            "SIMULATION-TIME": np.array([1, 2, 3]),
+            "TEMPERATURE": np.array([300.0, 301.0, 302.0]),
+            "PRESSURE": np.array([1.0, 1.5, 1.25]),
+        }
+        self.simulation_time = self.data["SIMULATION-TIME"]
+
+
 class FakeReader:
 
     def __init__(self, energies, filenames=None):
@@ -45,6 +71,12 @@ class FakeReader:
 
     def read_last(self):
         return None
+
+
+class FailingReader(FakeReader):
+
+    def read_last(self):
+        raise ValueError("file is being written")
 
 
 class FakeApp:
@@ -71,6 +103,15 @@ class FakeApp:
         self.running_average = FakeFlag(running_average)
         self.window_size = FakeEntry(window_size)
         self.plot_main_data = FakeFlag(False)
+        self.info = ["TEMPERATURE", "PRESSURE"]
+        self.focus_calls = []
+        self.appearance_mode = "Light"
+
+    def select_plot(self, plot):
+        self.selected_plot = plot
+
+    def open_focus_plot(self, parameter):
+        self.focus_calls.append(parameter)
 
 
 def teardown_function():
@@ -218,3 +259,41 @@ def test_time_self_correlation_mean_uses_data_scale():
     assert np.allclose(line.get_ydata(),
                        [8.6666, 10, 11, 10, 8.6666],
                        rtol=1e-4)
+
+
+def test_dashboard_plots_all_parameters_as_raw_overview():
+    app = FakeApp([FakeDashboardEnergy()])
+    plot = PlotDashboard(app)
+
+    plot.redraw()
+
+    assert plot.axis_parameters[plot.axes[0]] == "TEMPERATURE"
+    assert plot.axis_parameters[plot.axes[1]] == "PRESSURE"
+    assert plot.axes[0].get_title() == "TEMPERATURE / K"
+    assert plot.axes[1].get_title() == "PRESSURE / bar"
+    assert len(plot.axes[0].lines) == 1
+    assert len(plot.axes[1].lines) == 1
+    assert len(plot.figure.legends) == 1
+
+
+def test_dashboard_double_click_opens_focused_parameter_plot():
+    app = FakeApp([FakeDashboardEnergy()])
+    plot = PlotDashboard(app)
+    plot.redraw()
+
+    event = SimpleNamespace(dblclick=True, inaxes=plot.axes[1])
+
+    plot._PlotDashboard__button_press_event(event)
+
+    assert app.focus_calls == ["PRESSURE"]
+
+
+def test_dashboard_refresh_keeps_existing_plot_on_read_error(caplog):
+    app = FakeApp([FakeDashboardEnergy()])
+    app.reader = FailingReader([FakeDashboardEnergy()])
+    plot = PlotDashboard(app)
+    plot.redraw()
+
+    plot.refresh()
+
+    assert "Dashboard refresh skipped: file is being written" in caplog.text

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -269,8 +269,8 @@ def test_dashboard_plots_all_parameters_as_raw_overview():
 
     assert plot.axis_parameters[plot.axes[0]] == "TEMPERATURE"
     assert plot.axis_parameters[plot.axes[1]] == "PRESSURE"
-    assert plot.axes[0].get_title() == "TEMPERATURE / K"
-    assert plot.axes[1].get_title() == "PRESSURE / bar"
+    assert plot.axes[0].get_title(loc="left") == "TEMPERATURE / K"
+    assert plot.axes[1].get_title(loc="left") == "PRESSURE / bar"
     assert len(plot.axes[0].lines) == 1
     assert len(plot.axes[1].lines) == 1
     assert len(plot.figure.legends) == 1
@@ -288,6 +288,27 @@ def test_dashboard_double_click_opens_focused_parameter_plot():
     assert app.focus_calls == ["PRESSURE"]
 
 
+def test_dashboard_single_click_highlights_panel_without_opening_focus():
+    app = FakeApp([FakeDashboardEnergy()])
+    plot = PlotDashboard(app)
+    plot.redraw()
+
+    event = SimpleNamespace(dblclick=False, inaxes=plot.axes[1])
+
+    plot._PlotDashboard__button_press_event(event)
+
+    assert plot.selected_parameter == "PRESSURE"
+    assert app.focus_calls == []
+    assert all(
+        np.isclose(spine.get_linewidth(), 2.1)
+        for spine in plot.axes[1].spines.values()
+    )
+    assert all(
+        np.isclose(spine.get_linewidth(), 1.0)
+        for spine in plot.axes[0].spines.values()
+    )
+
+
 def test_dashboard_refresh_keeps_existing_plot_on_read_error(caplog):
     app = FakeApp([FakeDashboardEnergy()])
     app.reader = FailingReader([FakeDashboardEnergy()])
@@ -297,3 +318,5 @@ def test_dashboard_refresh_keeps_existing_plot_on_read_error(caplog):
     plot.refresh()
 
     assert "Dashboard refresh skipped: file is being written" in caplog.text
+    assert "refresh skipped: file is being written" in plot.subtitle_text.get_text()
+    assert len(plot.axes[0].lines) == 1

--- a/tests/plots/test_theme.py
+++ b/tests/plots/test_theme.py
@@ -29,6 +29,7 @@ def test_apply_figure_theme_updates_existing_plot_elements():
         axes.plot([1, 2], [3, 4], label="data")
         axes.set_xlabel("Simulation step")
         axes.set_ylabel("Energy")
+        axes.set_title("Energy trace", loc="left")
         axes.text(
             2,
             4,
@@ -43,6 +44,8 @@ def test_apply_figure_theme_updates_existing_plot_elements():
         assert axes.get_facecolor() == to_rgba(palette["axes.facecolor"])
         assert axes.xaxis.label.get_color() == palette["axes.labelcolor"]
         assert axes.yaxis.label.get_color() == palette["axes.labelcolor"]
+        assert axes.get_title(loc="left") == "Energy trace"
+        assert axes._left_title.get_color() == palette["text.color"]
         assert axes.get_legend().get_texts()[0].get_color() == palette[
             "text.color"]
         assert axes.texts[0].get_color() == palette["text.color"]


### PR DESCRIPTION
## Summary
- add a raw live dashboard with one panel per parameter for simulation monitoring
- double-click dashboard panels to open focused time-series plots
- store plot options per focused plot so statistic controls edit the selected plot live
- keep dashboard panels raw while focused plots support overlays and refresh/follow behavior
- tolerate temporary refresh read errors while files are being written
- refine the light/dark plot theme with stronger palettes, softer grids, cleaner legends, latest-value labels, selected-panel emphasis, and clearer focus-plot overlay styles

## Validation
- `python -m pip install .`
- `python -m pytest tests/plots/test_gui_plots.py tests/apps/test_app.py -q`
- `python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing --cov-report=xml -q`
- `python -m pytest -m e2e -q`
- `git diff --check`

Closes #34