### PR TITLE
Add file-watched live updates

### DIFF
--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -11,6 +11,7 @@ from .._logging import get_logger
 from ..plots import PlotDashboard, PlotTime, PlotHistogram
 from ..plots.options import PlotOptions
 from ..plots.theme import apply_matplotlib_theme, resolve_appearance_mode
+from .file_watcher import FileChangeWatcher
 from .app_layout import (
     configure_default_theme,
     configure_window,
@@ -61,6 +62,8 @@ class App(ctk.CTk):
         self.list_of_plots = []
         self.selected_plot = None
         self.__syncing_plot_controls = False
+        self.__file_watcher = None
+        self.__auto_refresh_after_id = None
 
         signal.signal(signal.SIGINT,
                       lambda sig, frame: self.destroy())
@@ -69,6 +72,7 @@ class App(ctk.CTk):
         """
         Destroy the app.
         """
+        self.__stop_file_watcher()
         plt.close("all")
         self.quit()
         super().destroy()
@@ -80,11 +84,16 @@ class App(ctk.CTk):
         self.sidebar_view = SidebarView(
             self, self.__change_appearance_mode_event)
         self.plot_controls_view = PlotControlsView(
-            self, self.__plot_button_event, self.__refresh_plots)
+            self,
+            self.__plot_button_event,
+            self.__auto_refresh_control_event,
+        )
         self.parameter_selector_view = ParameterSelectorView(
             self, self.__change_info_event)
         self.statistics_controls_view = StatisticsControlsView(
             self, self.__statistics_control_event)
+        if "auto_refresh" in self.__dict__:
+            self.__auto_refresh_control_event()
 
     def validate_number(self, value):
         """
@@ -145,7 +154,7 @@ class App(ctk.CTk):
 
         self.__selected_info = new_info
 
-    def __refresh_plots(self):
+    def __refresh_plots(self, show=True):
         """
         Refresh open plots and forget plots whose windows were closed.
         """
@@ -164,7 +173,96 @@ class App(ctk.CTk):
                     self.select_plot(None)
                 continue
 
-            plot.refresh()
+            plot.refresh(show=show)
+
+    def __schedule_auto_refresh(self):
+        """
+        Debounce file-change events into one GUI-thread refresh.
+        """
+
+        if not self.auto_refresh.get():
+            return None
+
+        if self.__auto_refresh_after_id is not None:
+            self.after_cancel(self.__auto_refresh_after_id)
+
+        self.__auto_refresh_after_id = self.after(
+            250,
+            self.__auto_refresh_plots,
+        )
+
+        return None
+
+    def __auto_refresh_plots(self):
+        """
+        Refresh plots after a watched input file changes.
+        """
+
+        self.__auto_refresh_after_id = None
+        self.__refresh_plots(show=False)
+
+        return None
+
+    def __auto_refresh_control_event(self):
+        """
+        Start or stop file watching from the Auto-Refresh checkbox.
+        """
+
+        if self.auto_refresh.get():
+            if self.__start_file_watcher():
+                self.__set_auto_refresh_status("Watching for file changes")
+        else:
+            self.__stop_file_watcher()
+            self.__set_auto_refresh_status("Auto-refresh paused")
+
+        return None
+
+    def __start_file_watcher(self):
+        """
+        Start watching the currently loaded files.
+        """
+
+        if self.__file_watcher is not None:
+            return True
+
+        watcher = FileChangeWatcher(
+            self.reader.filenames,
+            self.__schedule_auto_refresh,
+        )
+        if watcher.start():
+            self.__file_watcher = watcher
+            return True
+        else:
+            self.__set_checkbox(self.auto_refresh, False)
+            self.__set_auto_refresh_status("Auto-refresh unavailable")
+
+        return False
+
+    def __stop_file_watcher(self):
+        """
+        Stop the active file watcher, if any.
+        """
+
+        if self.__dict__.get("_App__auto_refresh_after_id") is not None:
+            self.after_cancel(self.__auto_refresh_after_id)
+            self.__auto_refresh_after_id = None
+
+        if self.__dict__.get("_App__file_watcher") is None:
+            return None
+
+        self.__file_watcher.stop()
+        self.__file_watcher = None
+
+        return None
+
+    def __set_auto_refresh_status(self, message):
+        """
+        Update the Auto-Refresh status label when the view exists.
+        """
+
+        status_label = self.__dict__.get("auto_refresh_status_label")
+        if status_label is not None:
+            status_label.configure(text=message)
 
     def __redraw_plots(self):
         """
@@ -200,15 +298,6 @@ class App(ctk.CTk):
         else:
             raise ValueError(f"Unknown plot event: {event}")
 
-        interval = None
-        if self.follow.get():
-            try:
-                interval = self.parse_positive_float(
-                    self.interval.get(), 1.0, "Interval")
-            except ValueError as error:
-                logger.warning("%s", error)
-                return None
-
         plot = plot_factory(self)
 
         self.list_of_plots.append(plot)
@@ -219,33 +308,18 @@ class App(ctk.CTk):
         else:
             info_parameter = self.__selected_info
 
-        if interval is not None:
-            plot.follow(info_parameter, interval)
-        else:
-            plot.simple(info_parameter)
+        plot.simple(info_parameter)
 
     def open_focus_plot(self, info_parameter):
         """
         Open a focused time-series plot for one dashboard parameter.
         """
 
-        interval = None
-        if self.follow.get():
-            try:
-                interval = self.parse_positive_float(
-                    self.interval.get(), 1.0, "Interval")
-            except ValueError as error:
-                logger.warning("%s", error)
-                return None
-
         self.__change_info_event(info_parameter)
         plot = PlotTime(self)
         self.list_of_plots.append(plot)
 
-        if interval is not None:
-            plot.follow(info_parameter, interval)
-        else:
-            plot.simple(info_parameter)
+        plot.simple(info_parameter)
 
     def select_plot(self, plot):
         """

--- a/PQEnalyzer/apps/app_layout.py
+++ b/PQEnalyzer/apps/app_layout.py
@@ -109,15 +109,19 @@ class PlotControlsView:
     """
     Plot command controls.
 
-    This view exposes the ``follow``, ``plot_main_data`` and interval widgets on
-    the app because ``Plot`` reads that state when a plot window is created or
-    refreshed.
+    This view exposes plot state widgets on the app because ``Plot`` reads that
+    state when a plot window is created or refreshed.
     """
 
-    def __init__(self, app, plot_button_callback, refresh_callback):
+    def __init__(
+        self,
+        app,
+        plot_button_callback,
+        auto_refresh_callback,
+    ):
         self.app = app
         self.plot_button_callback = plot_button_callback
-        self.refresh_callback = refresh_callback
+        self.auto_refresh_callback = auto_refresh_callback
 
         self.frame = ctk.CTkFrame(app, width=200)
         self.frame.grid(row=2,
@@ -125,22 +129,23 @@ class PlotControlsView:
                         sticky="nsew",
                         padx=(20, 20),
                         pady=(10, 10))
-        self.frame.grid_rowconfigure(5, weight=1)
+        self.frame.grid_rowconfigure(4, weight=1)
         self.frame.grid_columnconfigure(2, weight=1)
 
-        self.follow = tkinter.BooleanVar()
-        self.follow_checkbox = ctk.CTkCheckBox(
+        self.auto_refresh = tkinter.BooleanVar()
+        self.auto_refresh.set(True)
+        self.auto_refresh_checkbox = ctk.CTkCheckBox(
             master=self.frame,
             border_width=2,
-            text="Follow",
-            variable=self.follow,
-            command=lambda: app.toggle_entry_state(
-                self.follow_checkbox, self.interval_entry, default="1.0"))
-        self.follow_checkbox.grid(row=0,
-                                  column=1,
-                                  padx=(10, 10),
-                                  pady=(10, 10),
-                                  sticky="nsew")
+            text="Auto-Refresh",
+            variable=self.auto_refresh,
+            command=auto_refresh_callback,
+        )
+        self.auto_refresh_checkbox.grid(row=0,
+                                        column=1,
+                                        padx=(10, 10),
+                                        pady=(10, 10),
+                                        sticky="nsew")
 
         self.plot_main_data = tkinter.BooleanVar()
         self.no_data_checkbox = ctk.CTkCheckBox(
@@ -155,27 +160,17 @@ class PlotControlsView:
                                    pady=(10, 10),
                                    sticky="nsew")
 
-        self.interval_entry = ctk.CTkEntry(
+        self.auto_refresh_status_label = ctk.CTkLabel(
             self.frame,
-            width=10,
-            validate="key",
-            validatecommand=(app.register(app.validate_number), "%P"),
+            text="Watching for file changes",
+            anchor="w",
         )
-        self.interval_entry.grid(row=1,
-                                 column=1,
-                                 padx=10,
-                                 pady=5,
-                                 sticky="we")
-        self.interval_entry.configure(state="disabled")
-
-        self.interval_label = ctk.CTkLabel(self.frame,
-                                           text="Interval (s):",
-                                           anchor="w")
-        self.interval_label.grid(row=1,
-                                 column=0,
-                                 padx=10,
-                                 pady=5,
-                                 sticky="w")
+        self.auto_refresh_status_label.grid(row=1,
+                                            column=0,
+                                            columnspan=2,
+                                            padx=10,
+                                            pady=(0, 5),
+                                            sticky="w")
 
         self.plot_button = ctk.CTkButton(
             master=self.frame,
@@ -206,7 +201,7 @@ class PlotControlsView:
         self.dashboard_button = ctk.CTkButton(
             master=self.frame,
             border_width=2,
-            text="Dashboard",
+            text="Live Monitor",
             command=lambda: plot_button_callback(2),
         )
         self.dashboard_button.grid(row=4,
@@ -216,30 +211,15 @@ class PlotControlsView:
                                    pady=(10, 10),
                                    sticky="nsew")
 
-        self.refresh_button = ctk.CTkButton(
-            master=self.frame,
-            border_width=2,
-            text="Refresh",
-            command=refresh_callback,
-        )
-        self.refresh_button.grid(row=5,
-                                 column=0,
-                                 columnspan=2,
-                                 padx=(10, 10),
-                                 pady=(10, 10),
-                                 sticky="nsew")
-
         app.plot_frame = self.frame
-        app.follow = self.follow
-        app.check_follow = self.follow_checkbox
+        app.auto_refresh = self.auto_refresh
+        app.check_auto_refresh = self.auto_refresh_checkbox
         app.plot_main_data = self.plot_main_data
         app.check_nodata = self.no_data_checkbox
-        app.interval = self.interval_entry
-        app.interval_label = self.interval_label
+        app.auto_refresh_status_label = self.auto_refresh_status_label
         app.button_plot = self.plot_button
         app.button_hist = self.histogram_button
         app.button_dashboard = self.dashboard_button
-        app.button_refresh = self.refresh_button
 
 
 class ParameterSelectorView:

--- a/PQEnalyzer/apps/file_watcher.py
+++ b/PQEnalyzer/apps/file_watcher.py
@@ -1,0 +1,105 @@
+"""
+File-change watcher used by the GUI auto-refresh flow.
+"""
+
+from pathlib import Path
+
+from .._logging import get_logger
+
+try:
+    from watchdog.events import FileSystemEventHandler
+    from watchdog.observers import Observer
+except ImportError:  # pragma: no cover - dependency is installed at runtime
+    FileSystemEventHandler = object
+    Observer = None
+
+
+logger = get_logger(__name__)
+
+
+class _InputFileEventHandler(FileSystemEventHandler):
+    """
+    Forward watchdog events for files currently loaded in the app.
+    """
+
+    def __init__(self, watcher):
+        self.watcher = watcher
+
+    def on_any_event(self, event):
+        """
+        Handle writes, atomically replaced files, and close-write events.
+        """
+
+        if event.event_type not in {"modified", "created", "moved", "closed"}:
+            return
+
+        self.watcher.notify(event)
+
+
+class FileChangeWatcher:
+    """
+    Watch loaded input files and call a callback when one changes.
+    """
+
+    def __init__(self, filenames, callback):
+        self.filenames = {Path(filename).resolve() for filename in filenames}
+        self.callback = callback
+        self.observer = None
+
+    def start(self) -> bool:
+        """
+        Start watching parent folders of the configured files.
+        """
+
+        if Observer is None:
+            logger.warning("Auto-refresh unavailable: watchdog is not installed.")
+            return False
+
+        self.observer = Observer()
+        handler = _InputFileEventHandler(self)
+        for directory in sorted({filename.parent for filename in self.filenames}):
+            self.observer.schedule(handler, str(directory), recursive=False)
+
+        self.observer.start()
+        return True
+
+    def stop(self) -> None:
+        """
+        Stop the background observer if it is running.
+        """
+
+        if self.observer is None:
+            return
+
+        self.observer.stop()
+        self.observer.join(timeout=1.0)
+        self.observer = None
+
+    def notify(self, event) -> None:
+        """
+        Run the callback when a watchdog event belongs to a loaded file.
+        """
+
+        if self.__matches_loaded_file(event):
+            self.callback()
+
+    def __matches_loaded_file(self, event) -> bool:
+        """
+        Return whether an event path is one of the loaded files.
+        """
+
+        if getattr(event, "is_directory", False):
+            return False
+
+        paths = [getattr(event, "src_path", None)]
+        destination = getattr(event, "dest_path", None)
+        if destination:
+            paths.append(destination)
+
+        for path in paths:
+            if path is None:
+                continue
+            if Path(path).resolve() in self.filenames:
+                return True
+
+        return False

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -180,7 +180,7 @@ class Plot(metaclass=ABCMeta):
 
         plt.show()
 
-    def refresh(self) -> None:
+    def refresh(self, show=True) -> None:
         """
         Refresh an existing plot with the latest file contents and options.
 
@@ -198,7 +198,8 @@ class Plot(metaclass=ABCMeta):
         self.redraw()
 
         # Show the plot
-        plt.show()
+        if show:
+            plt.show()
 
     def redraw(self, options=None) -> None:
         """

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -88,7 +88,7 @@ class PlotDashboard:
         )
         plt.show()
 
-    def refresh(self) -> None:
+    def refresh(self, show=True) -> None:
         """
         Refresh the dashboard while keeping the previous view on read errors.
         """
@@ -99,7 +99,8 @@ class PlotDashboard:
             return None
 
         self.redraw()
-        plt.show()
+        if show:
+            plt.show()
 
     def redraw(self) -> None:
         """
@@ -295,14 +296,22 @@ class PlotDashboard:
         palette = palette_for_appearance_mode(
             getattr(self.app, "appearance_mode", None))
         if self.refresh_warning:
-            subtitle = f"raw live monitor - refresh skipped: {self.refresh_warning}"
+            subtitle = (
+                "watching for file changes - refresh skipped: "
+                f"{self.refresh_warning}"
+            )
             color = palette["warning.color"]
+        elif getattr(self.app, "auto_refresh", None) is not None and (
+            not self.app.auto_refresh.get()
+        ):
+            subtitle = "auto-refresh paused - double-click a panel to focus"
+            color = palette["subtle.text"]
         else:
-            subtitle = "raw live monitor - double-click a panel to focus"
+            subtitle = "watching for file changes - double-click a panel to focus"
             color = palette["subtle.text"]
 
         self.figure.suptitle(
-            "Simulation Dashboard",
+            "Simulation Monitor",
             x=0.012,
             y=0.995,
             ha="left",
@@ -332,4 +341,4 @@ class PlotDashboard:
 
         manager = getattr(self.figure.canvas, "manager", None)
         if manager is not None and hasattr(manager, "set_window_title"):
-            manager.set_window_title("PQEnalyzer Dashboard")
+            manager.set_window_title("PQEnalyzer - Live Monitor")

--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ pqenalyzer md-01.en md-02.en md-03.en
 For two aligned runs, the GUI and terminal mode can plot a pointwise difference
 as the first input file minus the second input file.
 
-In GUI mode, `Dashboard` opens a live raw overview with one panel per
-parameter. Double-click a dashboard panel to open a focused plot for that
+In GUI mode, `Live Monitor` opens a raw overview with one panel per parameter.
+`Auto-Refresh` watches the loaded file for changes and redraws open plots when
+new simulation output is written. Disable `Auto-Refresh` to pause file
+watching. Double-click a monitor panel to open a focused plot for that
 parameter. Statistics and time-series overlay controls apply to the selected
-focused plot, while the dashboard stays raw for simulation monitoring.
+focused plot, while the monitor stays raw for simulation monitoring.
 
 ## Input Files
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "scipy",
     "plotext",
     "InquirerPy",
+    "watchdog",
 ]
 
 [project.optional-dependencies]

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -103,14 +103,18 @@ def reset_dummy_plots():
     DummyPlot.instances = []
 
 
-def make_app(follow=False, interval=""):
+def make_app(auto_refresh=True):
     app = object.__new__(app_module.App)
-    app.follow = FakeFlag(follow)
-    app.interval = FakeEntry(interval)
+    app.auto_refresh = FakeFlag(auto_refresh)
+    app.reader = SimpleNamespace(filenames=["/tmp/md.en"])
     app.list_of_plots = []
     app.selected_plot = None
     app._App__syncing_plot_controls = False
+    app._App__file_watcher = None
+    app._App__auto_refresh_after_id = None
     app._App__selected_info = "TEMPERATURE"
+    app.after = lambda delay, callback: "after-id"
+    app.after_cancel = lambda after_id: None
     return app
 
 
@@ -262,10 +266,18 @@ def test_plot_controls_view_exposes_dashboard_button(monkeypatch):
     monkeypatch.setattr(app_layout.tkinter, "BooleanVar",
                         lambda: FakeFlag(False))
 
-    view = app_layout.PlotControlsView(app, lambda event: event, lambda: None)
+    view = app_layout.PlotControlsView(
+        app,
+        lambda event: event,
+        lambda: None,
+    )
 
     assert app.button_dashboard is view.dashboard_button
-    assert app.button_dashboard.kwargs["text"] == "Dashboard"
+    assert app.button_dashboard.kwargs["text"] == "Live Monitor"
+    assert app.check_auto_refresh is view.auto_refresh_checkbox
+    assert app.check_auto_refresh.kwargs["text"] == "Auto-Refresh"
+    assert app.auto_refresh.value is True
+    assert not hasattr(app, "button_refresh")
 
 
 def test_statistics_controls_view_exposes_plot_state_attributes(monkeypatch):
@@ -369,29 +381,18 @@ def test_statistics_control_callback_runs_after_difference_default(
     assert calls == ["run"]
 
 
-def test_plot_button_rejects_invalid_follow_interval(monkeypatch, caplog):
-    app = make_app(follow=True, interval="0")
-    monkeypatch.setattr(app_module, "PlotTime", DummyPlot)
-
-    app_module.App._App__plot_button_event(app, 0)
-
-    assert app.list_of_plots == []
-    assert DummyPlot.instances == []
-    assert "Interval must be greater than zero" in caplog.text
-
-
-def test_plot_button_passes_valid_follow_interval(monkeypatch):
-    app = make_app(follow=True, interval="2.5")
+def test_plot_button_runs_simple_time_plot_with_auto_refresh(monkeypatch):
+    app = make_app(auto_refresh=True)
     monkeypatch.setattr(app_module, "PlotTime", DummyPlot)
 
     app_module.App._App__plot_button_event(app, 0)
 
     assert app.list_of_plots == DummyPlot.instances
-    assert DummyPlot.instances[0].calls == [("follow", "TEMPERATURE", 2.5)]
+    assert DummyPlot.instances[0].calls == [("simple", "TEMPERATURE")]
 
 
 def test_plot_button_runs_simple_histogram(monkeypatch):
-    app = make_app(follow=False)
+    app = make_app(auto_refresh=False)
     monkeypatch.setattr(app_module, "PlotHistogram", DummyPlot)
 
     app_module.App._App__plot_button_event(app, 1)
@@ -401,7 +402,7 @@ def test_plot_button_runs_simple_histogram(monkeypatch):
 
 
 def test_plot_button_runs_dashboard(monkeypatch):
-    app = make_app(follow=False)
+    app = make_app(auto_refresh=False)
     monkeypatch.setattr(app_module, "PlotDashboard", DummyPlot)
 
     app_module.App._App__plot_button_event(app, 2)
@@ -539,8 +540,9 @@ def test_refresh_applies_controls_to_selected_plot(monkeypatch):
             self.options = PlotOptions()
             self.refreshed = False
 
-        def refresh(self):
+        def refresh(self, show=True):
             self.refreshed = True
+            self.show = show
 
     plot = SelectedPlot()
     app.selected_plot = plot
@@ -550,8 +552,106 @@ def test_refresh_applies_controls_to_selected_plot(monkeypatch):
     app_module.App._App__refresh_plots(app)
 
     assert plot.refreshed is True
+    assert plot.show is True
     assert plot.options.running_average is True
     assert plot.options.window_size == "15"
+
+
+def test_auto_refresh_control_starts_and_stops_file_watcher(monkeypatch):
+    app = make_app(auto_refresh=True)
+    status = FakeWidget()
+    app.auto_refresh_status_label = status
+    created_watchers = []
+
+    class FakeWatcher:
+
+        def __init__(self, filenames, callback):
+            self.filenames = filenames
+            self.callback = callback
+            self.started = False
+            self.stopped = False
+            created_watchers.append(self)
+
+        def start(self):
+            self.started = True
+            return True
+
+        def stop(self):
+            self.stopped = True
+
+    monkeypatch.setattr(app_module, "FileChangeWatcher", FakeWatcher)
+
+    app_module.App._App__auto_refresh_control_event(app)
+
+    assert created_watchers[0].filenames == ["/tmp/md.en"]
+    assert created_watchers[0].started is True
+    assert status.configure_kwargs["text"] == "Watching for file changes"
+
+    app.auto_refresh.set(False)
+    app_module.App._App__auto_refresh_control_event(app)
+
+    assert created_watchers[0].stopped is True
+    assert app._App__file_watcher is None
+    assert status.configure_kwargs["text"] == "Auto-refresh paused"
+
+
+def test_auto_refresh_control_disables_toggle_when_watcher_unavailable(
+        monkeypatch):
+    app = make_app(auto_refresh=True)
+    status = FakeWidget()
+    app.auto_refresh_status_label = status
+
+    class FakeWatcher:
+
+        def __init__(self, filenames, callback):
+            pass
+
+        def start(self):
+            return False
+
+    monkeypatch.setattr(app_module, "FileChangeWatcher", FakeWatcher)
+
+    app_module.App._App__auto_refresh_control_event(app)
+
+    assert app.auto_refresh.value is False
+    assert status.configure_kwargs["text"] == "Auto-refresh unavailable"
+
+
+def test_auto_refresh_debounces_file_events():
+    app = make_app(auto_refresh=True)
+    calls = []
+
+    app._App__auto_refresh_after_id = "old"
+    app.after_cancel = lambda after_id: calls.append(("cancel", after_id))
+    app.after = lambda delay, callback: calls.append(
+        ("after", delay, callback.__name__)) or "new"
+
+    app_module.App._App__schedule_auto_refresh(app)
+
+    assert app._App__auto_refresh_after_id == "new"
+    assert calls == [
+        ("cancel", "old"),
+        ("after", 250, "__auto_refresh_plots"),
+    ]
+
+
+def test_auto_refresh_redraws_open_plots_without_show(monkeypatch):
+    app = make_app(auto_refresh=True)
+    calls = []
+
+    class OpenPlot:
+        figure = SimpleNamespace(number=1)
+
+        def refresh(self, show=True):
+            calls.append(show)
+
+    app.list_of_plots = [OpenPlot()]
+    monkeypatch.setattr(app_module.plt, "get_fignums", lambda: [1])
+
+    app_module.App._App__auto_refresh_plots(app)
+
+    assert app._App__auto_refresh_after_id is None
+    assert calls == [False]
 
 
 def test_terminal_app_passes_difference_choice_for_two_files(monkeypatch):

--- a/tests/apps/test_file_watcher.py
+++ b/tests/apps/test_file_watcher.py
@@ -1,0 +1,96 @@
+from types import SimpleNamespace
+
+from PQEnalyzer.apps import file_watcher
+from PQEnalyzer.apps.file_watcher import FileChangeWatcher
+
+
+def test_file_change_watcher_notifies_for_loaded_file(tmp_path):
+    energy_file = tmp_path / "run.en"
+    calls = []
+    watcher = FileChangeWatcher([energy_file], lambda: calls.append("run"))
+    event = SimpleNamespace(
+        event_type="modified",
+        is_directory=False,
+        src_path=str(energy_file),
+    )
+
+    watcher.notify(event)
+
+    assert calls == ["run"]
+
+
+def test_file_change_watcher_notifies_for_moved_destination(tmp_path):
+    energy_file = tmp_path / "run.en"
+    replacement = tmp_path / ".run.en.tmp"
+    calls = []
+    watcher = FileChangeWatcher([energy_file], lambda: calls.append("run"))
+    event = SimpleNamespace(
+        event_type="moved",
+        is_directory=False,
+        src_path=str(replacement),
+        dest_path=str(energy_file),
+    )
+
+    watcher.notify(event)
+
+    assert calls == ["run"]
+
+
+def test_file_change_watcher_ignores_directories_and_unloaded_files(tmp_path):
+    energy_file = tmp_path / "run.en"
+    other_file = tmp_path / "other.en"
+    calls = []
+    watcher = FileChangeWatcher([energy_file], lambda: calls.append("run"))
+
+    watcher.notify(
+        SimpleNamespace(is_directory=True, src_path=str(energy_file)))
+    watcher.notify(
+        SimpleNamespace(is_directory=False, src_path=str(other_file)))
+
+    assert calls == []
+
+
+def test_file_change_watcher_schedules_unique_parent_directories(
+        tmp_path, monkeypatch):
+    first = tmp_path / "a" / "first.en"
+    second = tmp_path / "a" / "second.en"
+    third = tmp_path / "b" / "third.en"
+    scheduled = []
+
+    class FakeObserver:
+
+        def schedule(self, handler, directory, recursive):
+            scheduled.append((handler, directory, recursive))
+
+        def start(self):
+            scheduled.append(("start", None, None))
+
+        def stop(self):
+            scheduled.append(("stop", None, None))
+
+        def join(self, timeout=None):
+            scheduled.append(("join", timeout, None))
+
+    monkeypatch.setattr(file_watcher, "Observer", FakeObserver)
+
+    watcher = FileChangeWatcher([first, second, third], lambda: None)
+
+    assert watcher.start() is True
+    watcher.stop()
+
+    assert [entry[1] for entry in scheduled[:2]] == [
+        str(tmp_path / "a"),
+        str(tmp_path / "b"),
+    ]
+    assert scheduled[0][2] is False
+    assert scheduled[1][2] is False
+    assert scheduled[2] == ("start", None, None)
+    assert scheduled[-2:] == [("stop", None, None), ("join", 1.0, None)]
+
+
+def test_file_change_watcher_reports_unavailable_observer(monkeypatch):
+    monkeypatch.setattr(file_watcher, "Observer", None)
+
+    watcher = FileChangeWatcher(["run.en"], lambda: None)
+
+    assert watcher.start() is False


### PR DESCRIPTION
## Summary
- replace GUI follow interval controls with a default-on Auto-Refresh toggle backed by filesystem watching
- refresh open time, histogram, and monitor plots when loaded files change without opening extra plot windows
- keep Live Monitor raw for simulation monitoring and remove the manual refresh button
- document the updated GUI flow and add watcher/control tests

## Validation
- python -m pip install .
- git diff --check
- python -m pytest tests/apps/test_app.py tests/apps/test_file_watcher.py tests/plots/test_gui_plots.py -q
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing --cov-report=xml -q
- python -m pytest -m e2e -q

Stacked on #62.