### PR TITLE
Add scriptable no-GUI mode

### DIFF
--- a/PQEnalyzer/__main__.py
+++ b/PQEnalyzer/__main__.py
@@ -7,6 +7,8 @@ plotting flow. GUI imports stay inside main() so terminal mode can start
 without loading Tkinter.
 """
 
+# PYTHON_ARGCOMPLETE_OK
+
 import sys
 import argparse
 import argcomplete
@@ -18,6 +20,123 @@ from ._logging import configure_logging, get_logger
 logger = get_logger(__name__)
 
 
+PLOT_PARAMETER_COMPLETIONS = (
+    "TEMPERATURE",
+    "PRESSURE",
+    "E(TOT)",
+    "E(QM)",
+    "N(QM-ATOMS)",
+    "E(KIN)",
+    "E(INTRA)",
+    "VOLUME",
+    "DENSITY",
+    "MOMENTUM",
+    "LOOPTIME",
+    "BOX-X",
+    "BOX-Y",
+    "BOX-Z",
+    "ALPHA",
+    "BETA",
+    "GAMMA",
+    "BOX-VOLUME",
+)
+COMPLETION_SHELLS = ("bash", "zsh", "fish")
+
+
+def _handle_completion_command(argv):
+    """
+    Print a shell completion script for package-manager installation.
+    """
+
+    if len(argv) <= 1 or argv[1] != "completion":
+        return False
+
+    parser = argparse.ArgumentParser(
+        prog="pqenalyzer completion",
+        description="Print shell completion code for pqenalyzer.",
+    )
+    parser.add_argument("shell", choices=COMPLETION_SHELLS)
+    args = parser.parse_args(argv[2:])
+
+    sys.stdout.write(argcomplete.shellcode(["pqenalyzer"], shell=args.shell))
+    return True
+
+
+def _completion_matches(parameters, prefix):
+    """
+    Return case-insensitive parameter completions for argcomplete.
+    """
+
+    normalized_prefix = prefix.casefold()
+    return [
+        parameter for parameter in parameters
+        if parameter.casefold().startswith(normalized_prefix)
+    ]
+
+
+def _detect_completion_parameters(parsed_args):
+    """
+    Return parameters from the currently supplied input files, if readable.
+    """
+
+    filenames = getattr(parsed_args, "filenames", None) or []
+    if not filenames:
+        return []
+
+    forced_formats = [
+        getattr(parsed_args, "pq", False),
+        getattr(parsed_args, "qmcfc", False),
+        getattr(parsed_args, "box", False),
+    ]
+    if sum(forced_formats) > 1:
+        return []
+
+    input_format = "auto"
+    if getattr(parsed_args, "pq", False):
+        input_format = "pq"
+    elif getattr(parsed_args, "qmcfc", False):
+        input_format = "qmcfc"
+    elif getattr(parsed_args, "box", False):
+        input_format = "box"
+
+    previous_disable_level = None
+    try:
+        import logging
+
+        from .readers import create_reader
+
+        previous_disable_level = logging.root.manager.disable
+        logging.disable(logging.CRITICAL)
+        reader = create_reader(filenames, input_format=input_format)
+    except Exception:  # pylint: disable=broad-exception-caught
+        return []
+    finally:
+        if previous_disable_level is not None:
+            logging.disable(previous_disable_level)
+
+    return [*reader.energies[0].info][1:]
+
+
+def _complete_plot_parameter(prefix, parsed_args, **kwargs):
+    """
+    Complete --plot with detected parameters or common PQ/box defaults.
+    """
+
+    parameters = _detect_completion_parameters(parsed_args)
+    if not parameters:
+        parameters = PLOT_PARAMETER_COMPLETIONS
+
+    return _completion_matches(parameters, prefix)
+
+
+def _completion_validator(completion, prefix):
+    """
+    Let parameter completions match case-insensitively.
+    """
+
+    return completion.casefold().startswith(prefix.casefold())
+
+
 def main():
     """
     Parse command-line arguments, read input files, and start the chosen UI.
@@ -26,7 +145,13 @@ def main():
     reader errors are logged through the application logger before returning a
     non-zero process exit.
     """
-    parser = argparse.ArgumentParser(description="PQEnalyzer - MolarVerse")
+    if _handle_completion_command(sys.argv):
+        return None
+
+    parser = argparse.ArgumentParser(
+        description="PQEnalyzer - MolarVerse",
+        epilog="Shell completion: pqenalyzer completion {bash,zsh,fish}",
+    )
     parser.add_argument(
         "filenames",
         metavar="filenames",
@@ -46,15 +171,38 @@ def main():
                         "--no-gui",
                         action="store_true",
                         help="Opens the terminal plotting feature.")
+    plot_argument = parser.add_argument(
+        "--plot",
+        metavar="PARAMETER",
+        help="Plot one parameter in no-GUI mode and exit.")
+    plot_argument.completer = _complete_plot_parameter
+    parser.add_argument("--diff",
+                        action="store_true",
+                        help="Plot the first input file minus the second.")
+    parser.add_argument("--summary",
+                        action="store_true",
+                        help="Print an input summary in no-GUI mode and exit.")
     parser.add_argument("-v",
                         "--version",
                         action="version",
                         version=f"PQEnalyzer {__version__}")
 
-    argcomplete.autocomplete(parser)
+    argcomplete.autocomplete(parser, validator=_completion_validator)
 
     args = parser.parse_args()
     configure_logging()
+
+    if args.plot and not args.no_gui:
+        parser.error("--plot requires --no-gui.")
+
+    if args.diff and not args.plot:
+        parser.error("--diff requires --plot.")
+
+    if args.summary and not args.no_gui:
+        parser.error("--summary requires --no-gui.")
+
+    if args.summary and args.plot:
+        parser.error("--summary and --plot are mutually exclusive.")
 
     from .readers import create_reader
 
@@ -81,7 +229,18 @@ def main():
         from .apps import TermApp
 
         termapp = TermApp(reader)
-        termapp.start()
+        try:
+            if args.summary:
+                print(termapp.summary())
+            elif args.plot:
+                if args.diff and len(reader.energies) != 2:
+                    parser.error("--diff requires exactly two input files.")
+                termapp.plot(args.plot, difference=args.diff)
+            else:
+                termapp.start()
+        except ValueError as error:
+            logger.error("%s", error)
+            sys.exit(1)
     else:
         from .apps import App
 

--- a/PQEnalyzer/apps/termapp.py
+++ b/PQEnalyzer/apps/termapp.py
@@ -4,6 +4,7 @@ Interactive terminal application for parameter selection and plotting.
 import signal
 from InquirerPy import inquirer
 
+from ..energy_access import parameter_unit, simulation_time
 from ..plots import TermPlot
 
 
@@ -36,6 +37,63 @@ class TermApp:
 
         return None
 
+    def plot(self, info_parameter, difference=False):
+        """
+        Render one parameter without prompting.
+        """
+
+        resolved_parameter = self.resolve_parameter(info_parameter)
+
+        if difference and len(self.reader.energies) != 2:
+            raise ValueError("Difference plotting requires exactly two files.")
+
+        termplot = TermPlot(self.reader)
+        termplot.plot(resolved_parameter, difference=difference)
+
+        return None
+
+    def summary(self):
+        """
+        Return a text summary for the loaded files and available parameters.
+        """
+
+        lines = [
+            "PQEnalyzer input summary",
+            f"Files: {len(self.reader.filenames)}",
+        ]
+
+        for filename, energy in zip(self.reader.filenames,
+                                    self.reader.energies):
+            lines.append(
+                f"  {filename}: {len(simulation_time(energy))} rows")
+
+        lines.extend([
+            f"Parameters: {len(self.info)}",
+        ])
+
+        for parameter in self.info:
+            unit = parameter_unit(self.reader.energies[0], parameter)
+            lines.append(f"  {parameter} [{unit}]")
+
+        return "\n".join(lines)
+
+    def resolve_parameter(self, info_parameter):
+        """
+        Return the canonical parameter name for user-provided input.
+        """
+
+        if info_parameter in self.info:
+            return info_parameter
+
+        normalized_parameter = info_parameter.casefold()
+        for parameter in self.info:
+            if parameter.casefold() == normalized_parameter:
+                return parameter
+
+        raise ValueError(
+            f"Unknown parameter: {info_parameter}. "
+            f"Available parameters: {', '.join(self.info)}.")
+
     def run(self):
         """
         Ask for one parameter and draw a terminal plot once.
@@ -56,8 +114,7 @@ class TermApp:
                 vi_mode=True,
             ).execute()
 
-        termplot = TermPlot(self.reader)
-        termplot.plot(result, difference=difference)
+        self.plot(result, difference=difference)
 
         return None
 

--- a/README.md
+++ b/README.md
@@ -30,11 +30,22 @@ Plot in the terminal instead of opening the GUI:
 pqenalyzer --no-gui pq_output.en
 ```
 
-Open two aligned example files in terminal mode and answer yes to the
-difference prompt:
+Plot one parameter in terminal mode without prompts:
 
 ```bash
-pqenalyzer --no-gui examples/diff-run-a.en examples/diff-run-b.en
+pqenalyzer --no-gui --plot TEMPERATURE pq_output.en
+```
+
+Print the detected files, row counts, and available parameters:
+
+```bash
+pqenalyzer --no-gui --summary pq_output.en
+```
+
+Plot the difference between two aligned example files without prompts:
+
+```bash
+pqenalyzer --no-gui --plot TEMPERATURE --diff examples/diff-run-a.en examples/diff-run-b.en
 ```
 
 Read QMCFC output:
@@ -56,6 +67,44 @@ pqenalyzer examples/box-01.box
 ```
 
 Use `--box` when a box file does not use the conventional `.box` suffix.
+
+## Shell Completion
+
+PQEnalyzer uses `argcomplete` for shell completion and can print installable
+completion scripts.
+
+Package managers can install the generated scripts into their shell completion
+directories so users get completion after installing the package.
+
+Enable bash completion for the current shell session:
+
+```bash
+eval "$(pqenalyzer completion bash)"
+```
+
+Enable zsh completion for the current shell session:
+
+```bash
+eval "$(pqenalyzer completion zsh)"
+```
+
+Install fish completion persistently:
+
+```bash
+mkdir -p ~/.config/fish/completions
+pqenalyzer completion fish > ~/.config/fish/completions/pqenalyzer.fish
+```
+
+To enable automatic argcomplete discovery for installed Python CLIs, run this
+once and restart the shell:
+
+```bash
+activate-global-python-argcomplete --user -y
+```
+
+After completion is active, `--plot` completes common PQ and box parameters.
+When input files are already present on the command line, it completes the
+parameters detected from those files.
 
 Multiple input files can be plotted together when they expose the same
 parameters and units:

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -657,6 +657,7 @@ def test_auto_refresh_redraws_open_plots_without_show(monkeypatch):
 def test_terminal_app_passes_difference_choice_for_two_files(monkeypatch):
     calls = []
     reader = SimpleNamespace(
+        filenames=["first.en", "second.en"],
         energies=[
             SimpleNamespace(info={"SIMULATION-TIME": "TIME",
                                   "PARAMETER": "PARAMETER"}),
@@ -690,3 +691,71 @@ def test_terminal_app_passes_difference_choice_for_two_files(monkeypatch):
     termapp_module.TermApp(reader).run()
 
     assert calls == [(reader, "PARAMETER", True)]
+
+
+def test_terminal_app_plots_selected_parameter_without_prompt(monkeypatch):
+    calls = []
+    reader = SimpleNamespace(
+        filenames=["run.en"],
+        energies=[
+            SimpleNamespace(
+                info={"SIMULATION-TIME": "TIME", "PARAMETER": "PARAMETER"},
+                units={"PARAMETER": "unit"},
+                data={"PARAMETER": [1, 2, 3]},
+                simulation_time=[1, 2, 3],
+            )
+        ],
+    )
+
+    class FakeTermPlot:
+
+        def __init__(self, plot_reader):
+            self.reader = plot_reader
+
+        def plot(self, info_parameter, difference=False):
+            calls.append((self.reader, info_parameter, difference))
+
+    monkeypatch.setattr(termapp_module, "TermPlot", FakeTermPlot)
+
+    termapp_module.TermApp(reader).plot("parameter", difference=False)
+
+    assert calls == [(reader, "PARAMETER", False)]
+
+
+def test_terminal_app_summary_lists_files_rows_and_units():
+    reader = SimpleNamespace(
+        filenames=["run.en"],
+        energies=[
+            SimpleNamespace(
+                info={"SIMULATION-TIME": "TIME", "PARAMETER": "PARAMETER"},
+                units={"PARAMETER": "unit"},
+                data={"PARAMETER": [1, 2, 3]},
+                simulation_time=[1, 2, 3],
+            )
+        ],
+    )
+
+    summary = termapp_module.TermApp(reader).summary()
+
+    assert "PQEnalyzer input summary" in summary
+    assert "Files: 1" in summary
+    assert "  run.en: 3 rows" in summary
+    assert "Parameters: 1" in summary
+    assert "  PARAMETER [unit]" in summary
+
+
+def test_terminal_app_rejects_unknown_parameter():
+    reader = SimpleNamespace(
+        filenames=["run.en"],
+        energies=[
+            SimpleNamespace(
+                info={"SIMULATION-TIME": "TIME", "PARAMETER": "PARAMETER"},
+                units={"PARAMETER": "unit"},
+                data={"PARAMETER": [1, 2, 3]},
+                simulation_time=[1, 2, 3],
+            )
+        ],
+    )
+
+    with pytest.raises(ValueError, match="Unknown parameter: missing"):
+        termapp_module.TermApp(reader).plot("missing")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,41 @@
+import os
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
+
+
+def complete_cli(command_line):
+    """
+    Run argcomplete against the source checkout and return completions.
+    """
+
+    project_root = Path(__file__).resolve().parents[1]
+
+    with tempfile.NamedTemporaryFile() as output:
+        result = subprocess.run(
+            [sys.executable, "-m", "PQEnalyzer"],
+            cwd=project_root,
+            env={
+                **dict(os.environ),
+                "_ARGCOMPLETE": "1",
+                "_ARGCOMPLETE_STDOUT_FILENAME": output.name,
+                "_ARGCOMPLETE_SHELL": "bash",
+                "COMP_LINE": command_line,
+                "COMP_POINT": str(len(command_line)),
+            },
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=20,
+        )
+        output.seek(0)
+        completions = output.read().decode("utf-8")
+
+    assert result.returncode == 0
+    assert result.stdout == ""
+    assert result.stderr == ""
+    return [completion.rstrip() for completion in completions.split("\013")]
 
 
 def test_cli_version_from_source_checkout():
@@ -17,6 +52,22 @@ def test_cli_version_from_source_checkout():
     assert result.returncode == 0
     assert "Traceback" not in result.stderr
     assert result.stdout.startswith("PQEnalyzer ")
+
+
+def test_cli_help_mentions_completion_command():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [sys.executable, "-m", "PQEnalyzer", "--help"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr
+    assert "pqenalyzer completion {bash,zsh,fish}" in result.stdout
 
 
 def test_cli_logs_reader_validation_errors():
@@ -66,6 +117,82 @@ def test_cli_does_not_duplicate_upstream_reader_errors():
     assert result.stderr.count(f"File {missing_file} not found.") == 1
 
 
+def test_cli_module_has_argcomplete_marker():
+    project_root = Path(__file__).resolve().parents[1]
+    module_head = (project_root / "PQEnalyzer" /
+                   "__main__.py").read_text(encoding="utf-8")[:1024]
+
+    assert "PYTHON_ARGCOMPLETE_OK" in module_head
+
+
+def test_cli_prints_bash_completion_script():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [sys.executable, "-m", "PQEnalyzer", "completion", "bash"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "_ARGCOMPLETE=1" in result.stdout
+    assert "complete " in result.stdout
+    assert "pqenalyzer" in result.stdout
+
+
+def test_cli_prints_zsh_completion_script():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [sys.executable, "-m", "PQEnalyzer", "completion", "zsh"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "#compdef pqenalyzer" in result.stdout
+    assert '_ARGCOMPLETE_SHELL="zsh"' in result.stdout
+
+
+def test_cli_prints_fish_completion_script():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [sys.executable, "-m", "PQEnalyzer", "completion", "fish"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+    assert "function __fish_pqenalyzer_complete" in result.stdout
+    assert "complete --command pqenalyzer" in result.stdout
+
+
+def test_cli_rejects_unknown_completion_shell():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [sys.executable, "-m", "PQEnalyzer", "completion", "powershell"],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "Traceback" not in result.stderr
+    assert "invalid choice: 'powershell'" in result.stderr
+
+
 def test_cli_rejects_multiple_forced_input_formats():
     project_root = Path(__file__).resolve().parents[1]
 
@@ -88,3 +215,99 @@ def test_cli_rejects_multiple_forced_input_formats():
     assert "Traceback" not in result.stderr
     assert "--pq, --qmcfc, and --box are mutually exclusive." in (
         result.stderr)
+
+
+def test_cli_no_gui_plot_exits_without_prompt():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "PQEnalyzer",
+            "--no-gui",
+            "--plot",
+            "TEMPERATURE",
+            "examples/md-01.en",
+        ],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr
+    assert "Select the information parameter" not in result.stdout
+    assert "TEMPERATURE / K" in result.stdout
+    assert "Simulation Time" in result.stdout
+
+
+def test_cli_no_gui_summary_prints_loaded_input_details():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "PQEnalyzer",
+            "--no-gui",
+            "--summary",
+            "examples/box-01.box",
+        ],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+
+    assert result.returncode == 0
+    assert "Traceback" not in result.stderr
+    assert "PQEnalyzer input summary" in result.stdout
+    assert "examples/box-01.box: 5 rows" in result.stdout
+    assert "BOX-X [A]" in result.stdout
+    assert "BOX-VOLUME [A^3]" in result.stdout
+
+
+def test_cli_diff_requires_two_input_files():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "PQEnalyzer",
+            "--no-gui",
+            "--plot",
+            "TEMPERATURE",
+            "--diff",
+            "examples/md-01.en",
+        ],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=20,
+    )
+
+    assert result.returncode == 2
+    assert "Traceback" not in result.stderr
+    assert "--diff requires exactly two input files." in result.stderr
+
+
+def test_cli_plot_parameter_completion_uses_common_defaults():
+    completions = complete_cli("pqenalyzer --no-gui --plot T")
+
+    assert completions == ["TEMPERATURE"]
+
+
+def test_cli_plot_parameter_completion_uses_detected_box_parameters():
+    completions = complete_cli(
+        "pqenalyzer --no-gui examples/box-01.box --plot B")
+
+    assert "BOX-X" in completions
+    assert "BOX-VOLUME" in completions
+    assert "BETA" in completions
+    assert "TEMPERATURE" not in completions


### PR DESCRIPTION
## Summary
- add non-interactive no-GUI plotting with `--plot PARAMETER`
- add `--diff` for deterministic two-run difference plots
- add `--summary` to list loaded files, row counts, and available parameters
- add `--plot` shell completion for common PQ/box parameters and detected input-file parameters
- add `pqenalyzer completion {bash,zsh,fish}` to print installable shell completion scripts
- keep existing interactive terminal mode as the default when no deterministic option is passed

## Autocomplete setup
- bash current shell: `eval "$(pqenalyzer completion bash)"`
- zsh current shell: `eval "$(pqenalyzer completion zsh)"`
- fish persistent install: `pqenalyzer completion fish > ~/.config/fish/completions/pqenalyzer.fish`
- automatic argcomplete discovery for installed Python CLIs: `activate-global-python-argcomplete --user -y`, then restart the shell

## Validation
- python -m pip install .
- git diff --check
- python -m pytest tests/test_cli.py -q
- manual `pqenalyzer completion` checks for bash, zsh, and fish
- manual argcomplete probes for static and detected `--plot` parameters
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing --cov-report=xml -q
- python -m pytest -m e2e -q