### PR TITLE
Improve plot value readouts

### DIFF
--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -295,18 +295,6 @@ class Plot(metaclass=ABCMeta):
         self.ax.ticklabel_format(axis="both", style="sci")
         self.ax.margins(x=0.02, y=0.08)
 
-    def annotation_box(self):
-        """
-        Return a themed rounded label box for latest-value annotations.
-        """
-
-        return dict(
-            boxstyle="round,pad=0.22",
-            facecolor=self.palette["annotation.facecolor"],
-            edgecolor=self.palette["annotation.edgecolor"],
-            alpha=0.88,
-        )
-
     def set_window_title(self, title: str) -> None:
         """
         Name the native matplotlib window when the backend supports it.

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -16,6 +16,7 @@ from .theme import (
     apply_matplotlib_theme,
     palette_for_appearance_mode,
 )
+from .value_readout import ValueReadoutEntry, format_readout_value
 
 
 logger = get_logger(__name__)
@@ -35,6 +36,7 @@ class PlotDashboard:
         self.reader = app.reader
         self.parameters = list(app.info)
         self.axis_parameters = {}
+        self.latest_values = {}
         self.selected_parameter = None
         self.refresh_warning = None
         self.subtitle_text = None
@@ -116,6 +118,7 @@ class PlotDashboard:
             )
 
         self.axis_parameters = {}
+        self.latest_values = {}
         labels = unique_path_labels(self.reader.filenames)
 
         for index, parameter in enumerate(self.parameters):
@@ -130,7 +133,9 @@ class PlotDashboard:
 
         self.__show_legend()
         self.__set_title()
-        self.figure.tight_layout(rect=(0, 0.03, 1, 0.91), h_pad=1.0)
+        self.figure.tight_layout(rect=(0, 0.03, 1, 0.92),
+                                 h_pad=1.0,
+                                 w_pad=1.2)
         self.figure.canvas.draw_idle()
 
     def __plot_parameter(self, ax, parameter, labels):
@@ -140,15 +145,19 @@ class PlotDashboard:
 
         for index, energy in enumerate(self.reader.energies):
             energy_series = series(energy, parameter)
-            ax.plot(
+            line = ax.plot(
                 energy_series.time,
                 energy_series.values,
                 label=labels[index],
                 linewidth=1.45,
                 alpha=0.92,
+            )[0]
+            self.__add_latest_value(
+                parameter,
+                labels[index],
+                line,
+                energy_series.values,
             )
-            self.__add_latest_value(ax, energy_series.time,
-                                    energy_series.values)
 
     def __label_axis(self, ax, parameter, index):
         """
@@ -156,7 +165,16 @@ class PlotDashboard:
         """
 
         unit = parameter_unit(self.reader.energies[0], parameter)
+        palette = palette_for_appearance_mode(
+            getattr(self.app, "appearance_mode", None))
         ax.set_title(f"{parameter} / {unit}", fontsize=9, loc="left", pad=6)
+        ax.set_title(
+            self.__latest_value_title(parameter),
+            fontsize=8,
+            loc="right",
+            pad=6,
+            color=palette["subtle.text"],
+        )
         ax.ticklabel_format(axis="both", style="sci")
         ax.tick_params(labelsize=8)
 
@@ -164,27 +182,55 @@ class PlotDashboard:
         if index // ncols == nrows - 1:
             ax.set_xlabel("Simulation step", fontsize=8)
 
-    def __add_latest_value(self, ax, x, y):
+    def __add_latest_value(self, parameter, label, line, values):
         """
-        Add a compact latest-value label to one dashboard line.
+        Store one dashboard line's latest value for the axis title.
         """
 
-        if len(x) == 0 or len(y) == 0:
+        if len(values) == 0:
             return
 
-        ax.annotate(
-            f"{y[-1]:.3e}",
-            xy=(x[-1], y[-1]),
-            xytext=(4, 0),
-            textcoords="offset points",
-            fontsize=6.5,
-            horizontalalignment="left",
-            verticalalignment="center",
-            bbox=dict(boxstyle="round,pad=0.18",
-                      facecolor="white",
-                      alpha=0.5,
-                      edgecolor="white"),
-        )
+        unit = parameter_unit(self.reader.energies[0], parameter)
+        self.latest_values.setdefault(parameter, []).append(
+            ValueReadoutEntry(
+                label=label,
+                value=float(values[-1]),
+                color=line.get_color(),
+                unit=unit,
+            ))
+
+    def __latest_value_title(self, parameter):
+        """
+        Return the compact latest-value text for a dashboard axis.
+        """
+
+        entries = self.latest_values.get(parameter, [])
+        if not entries:
+            return ""
+
+        if len(entries) == 1:
+            return entries[0].formatted_value
+
+        visible_entries = entries[:2]
+        title = self.__multi_value_title(visible_entries)
+        remaining = len(entries) - len(visible_entries)
+        if remaining > 0:
+            title = f"{title} | +{remaining}"
+        return title
+
+    def __multi_value_title(self, entries):
+        """
+        Return compact values for multi-file dashboard headers.
+        """
+
+        units = {entry.unit for entry in entries if entry.unit}
+        if len(units) == 1:
+            unit = entries[0].unit
+            values = " | ".join(
+                format_readout_value(entry.value) for entry in entries)
+            return f"{values} {unit}".rstrip()
+
+        return " | ".join(entry.formatted_value for entry in entries)
 
     def __show_legend(self):
         """
@@ -198,7 +244,7 @@ class PlotDashboard:
                     handles,
                     labels,
                     loc="upper right",
-                    bbox_to_anchor=(0.995, 0.995),
+                    bbox_to_anchor=(0.995, 0.985),
                     ncol=min(4, len(labels)),
                     fontsize="small",
                     frameon=True,
@@ -313,7 +359,7 @@ class PlotDashboard:
         self.figure.suptitle(
             "Simulation Monitor",
             x=0.012,
-            y=0.995,
+            y=0.985,
             ha="left",
             va="top",
             fontsize=14,
@@ -323,7 +369,7 @@ class PlotDashboard:
         if self.subtitle_text is None:
             self.subtitle_text = self.figure.text(
                 0.012,
-                0.955,
+                0.952,
                 subtitle,
                 ha="left",
                 va="top",

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -2,11 +2,12 @@
 Time-series plotting for PQ energy parameters.
 """
 
-from ..energy_access import series
+from ..energy_access import parameter_unit, series
 from .._logging import get_logger
 from .features import iter_time_series_overlays
 from .labels import unique_path_labels
 from .plot import Plot
+from .value_readout import latest_value_label
 
 
 logger = get_logger(__name__)
@@ -57,15 +58,16 @@ class PlotTime(Plot):
         labels = unique_path_labels(self.reader.filenames)
         for i, energy in enumerate(self.reader.energies):
             energy_series = series(energy, info_parameter)
+            unit = parameter_unit(energy, info_parameter)
             self.ax.plot(
                 energy_series.time,
                 energy_series.values,
-                label=labels[i],
+                label=latest_value_label(labels[i], energy_series.values,
+                                         unit),
                 linewidth=1.6,
                 alpha=0.92,
                 zorder=2,
             )
-            self.add_value_label(energy_series.time, energy_series.values)
 
     def labels(self, info_parameter: str) -> None:
         """
@@ -87,7 +89,14 @@ class PlotTime(Plot):
             ylabel=self.parameter_axis_label(info_parameter),
         )
 
-        if not self.show_legend(loc="best"):
+        if not self.show_legend(
+            loc="best",
+            fontsize="x-small",
+            framealpha=0.82,
+            borderpad=0.35,
+            labelspacing=0.28,
+            handlelength=1.8,
+        ):
             logger.warning("No data to plot.")
 
         return None
@@ -107,6 +116,7 @@ class PlotTime(Plot):
         """
 
         try:
+            unit = parameter_unit(self.reader.energies[0], info_parameter)
             for overlay in iter_time_series_overlays(
                 self.reader.energies,
                 info_parameter,
@@ -115,41 +125,11 @@ class PlotTime(Plot):
                 self.ax.plot(
                     overlay.time,
                     overlay.values,
-                    label=overlay.label,
+                    label=latest_value_label(overlay.label, overlay.values,
+                                             unit),
                     **overlay.feature.matplotlib_style,
                 )
-                self.add_value_label(overlay.time, overlay.values)
         except ValueError as error:
             logger.warning("%s", error)
-
-        return None
-
-    def add_value_label(self, x, y) -> None:
-        """
-        Add a value label for the last y point.
-
-        Parameters
-        ----------
-        x : float
-            The x coordinate of the value label.
-        y : float
-            The y coordinate of the value label.
-
-        Returns
-        -------
-        None
-        """
-
-        self.ax.annotate(
-            f"{y[-1]:.3e}",
-            xy=(x[-1], y[-1]),
-            xytext=(6, 0),
-            textcoords="offset points",
-            fontsize=8,
-            horizontalalignment="left",
-            verticalalignment="center",
-            bbox=self.annotation_box(),
-            zorder=5,
-        )
 
         return None

--- a/PQEnalyzer/plots/value_readout.py
+++ b/PQEnalyzer/plots/value_readout.py
@@ -1,0 +1,58 @@
+"""
+Readout helpers for presenting plotted values outside the data area.
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class ValueReadoutEntry:
+    """
+    One row in a plot value readout.
+    """
+
+    label: str
+    value: float
+    color: str
+    unit: str = ""
+    linestyle: str = "-"
+
+    @property
+    def formatted_value(self) -> str:
+        """
+        Return the value formatted for a compact plot readout.
+        """
+
+        return format_readout_value(self.value, self.unit)
+
+
+def format_readout_value(value, unit="") -> str:
+    """
+    Format a numeric value without forcing scientific notation unnecessarily.
+    """
+
+    if not np.isfinite(value):
+        text = "n/a"
+    else:
+        magnitude = abs(value)
+        if magnitude != 0 and (magnitude < 1e-3 or magnitude >= 1e5):
+            text = f"{value:.4e}"
+        else:
+            text = f"{value:.5g}"
+
+    return f"{text} {unit}".rstrip()
+
+
+def latest_value_label(label, values, unit="") -> str:
+    """
+    Return a legend label that includes the latest finite value.
+    """
+
+    values = np.asarray(values, dtype=float)
+    finite_values = values[np.isfinite(values)]
+    if finite_values.size == 0:
+        return label
+
+    return f"{label} ({format_readout_value(finite_values[-1], unit)})"

--- a/PQEnalyzer/statistics/statistic.py
+++ b/PQEnalyzer/statistics/statistic.py
@@ -204,7 +204,7 @@ class Statistic:
         Examples
         --------
         >>> Statistic.self_correlation_mean(energies, "ENERGY")
-        ([1, 2, 3, 4, 5], [8.6666, 10, 11, 10, 8.6666])
+        ([1, 2, 3, 4, 5], [2, 2.5, 3, 3.5, 4])
         """
 
         energy_series = concatenate_series(energies, info_parameter)
@@ -216,21 +216,22 @@ class Statistic:
         """
         Calculate the self-correlation mean for a numeric series.
 
-        The result is divided by the number of overlapping points at each lag
-        so every point is a mean product rather than an edge-biased sum.
+        The result stays on the original data scale. Each output point is the
+        mean of the values that overlap that lag, which avoids the squared
+        magnitude returned by an unnormalized product correlation.
         """
 
         time, data = Statistic.__arrays(time, values)
         data = data.astype(float)
 
-        numerator = np.correlate(data, data, mode="same")
-        denominator = np.correlate(
+        numerator = np.correlate(data, np.ones_like(data), mode="same")
+        overlap = np.correlate(
             np.ones_like(data), np.ones_like(data), mode="same")
         self_correlation_mean = np.divide(
             numerator,
-            denominator,
+            overlap,
             out=np.zeros_like(data),
-            where=denominator != 0,
+            where=overlap != 0,
         )
 
         return time, self_correlation_mean

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -5,6 +5,11 @@ from types import SimpleNamespace
 from PQEnalyzer.plots.plot_dashboard import PlotDashboard
 from PQEnalyzer.plots.plot_histogram import PlotHistogram
 from PQEnalyzer.plots.plot_time import PlotTime
+from PQEnalyzer.plots.value_readout import (
+    ValueReadoutEntry,
+    format_readout_value,
+    latest_value_label,
+)
 
 
 class FakeFlag:
@@ -170,18 +175,38 @@ def test_histogram_labels_use_distribution_title_and_density_axis():
     assert plot.ax.get_ylim()[0] == 0
 
 
-def test_time_main_data_uses_readable_filenames_and_value_labels():
+def test_time_main_data_uses_readable_filenames_and_latest_readout():
     app = FakeApp([FakeEnergy([1, 2, 3, 4])])
     plot = PlotTime(app)
 
     plot.main_data("PARAMETER")
 
-    assert plot.ax.get_legend_handles_labels()[1] == ["series-0.en"]
+    assert plot.ax.get_legend_handles_labels()[1] == [
+        "series-0.en (4 unit)"
+    ]
     assert plot.ax.lines[0].get_linewidth() == 1.6
     assert plot.ax.lines[0].get_alpha() == 0.92
     assert plot.ax.lines[0].get_zorder() == 2
-    assert len(plot.ax.texts) == 1
-    assert plot.ax.texts[0].get_text() == "4.000e+00"
+    assert len(plot.ax.texts) == 0
+
+
+def test_time_plot_renders_latest_values_in_legend_without_axis_labels():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])],
+                  mean=True,
+                  median=True)
+    plot = PlotTime(app)
+    plot.info_parameter = "PARAMETER"
+
+    plot.plot_data()
+
+    assert len(plot.ax.texts) == 0
+    assert plot.ax.get_legend_handles_labels()[1] == [
+        "series-0.en (4 unit)",
+        "Mean (2.5 unit)",
+        "Median (2.5 unit)",
+    ]
+    assert plot.ax.get_legend() is not None
+    assert plot.ax.get_legend().get_title().get_text() == ""
 
 
 def test_time_labels_use_time_series_title_and_parameter_axis():
@@ -206,8 +231,8 @@ def test_time_main_data_disambiguates_duplicate_filenames():
     plot.main_data("PARAMETER")
 
     assert plot.ax.get_legend_handles_labels()[1] == [
-        "run-a/md.en",
-        "run-b/md.en",
+        "run-a/md.en (4 unit)",
+        "run-b/md.en (5 unit)",
     ]
 
 
@@ -237,11 +262,11 @@ def test_time_statistics_draw_expected_overlay_series():
     plot.statistics("PARAMETER")
 
     assert plot.ax.get_legend_handles_labels()[1] == [
-        "Mean",
-        "Median",
-        "Cumulative Average",
-        "Self-Correlation Mean",
-        "Running Average (2)",
+        "Mean (2.5 unit)",
+        "Median (2.5 unit)",
+        "Cumulative Average (2.5 unit)",
+        "Self-Correlation Mean (3 unit)",
+        "Running Average (2) (3.5 unit)",
     ]
     assert [line.get_linestyle() for line in plot.ax.lines[:3]] == [
         "--",
@@ -265,7 +290,7 @@ def test_time_difference_subtracts_two_aligned_series():
     assert len(plot.ax.lines) == 1
     line = plot.ax.lines[0]
 
-    assert line.get_label() == "Difference (1 - 2)"
+    assert line.get_label() == "Difference (1 - 2) (3 unit)"
     assert np.all(line.get_xdata() == [1, 2, 3])
     assert np.all(line.get_ydata() == [4, 4, 3])
 
@@ -292,11 +317,9 @@ def test_time_self_correlation_mean_uses_data_scale():
 
     line = plot.ax.lines[0]
 
-    assert line.get_label() == "Self-Correlation Mean"
+    assert line.get_label() == "Self-Correlation Mean (4 unit)"
     assert np.all(line.get_xdata() == [1, 2, 3, 4, 5])
-    assert np.allclose(line.get_ydata(),
-                       [8.6666, 10, 11, 10, 8.6666],
-                       rtol=1e-4)
+    assert np.allclose(line.get_ydata(), [2, 2.5, 3, 3.5, 4])
 
 
 def test_dashboard_plots_all_parameters_as_raw_overview():
@@ -309,9 +332,50 @@ def test_dashboard_plots_all_parameters_as_raw_overview():
     assert plot.axis_parameters[plot.axes[1]] == "PRESSURE"
     assert plot.axes[0].get_title(loc="left") == "TEMPERATURE / K"
     assert plot.axes[1].get_title(loc="left") == "PRESSURE / bar"
+    assert plot.axes[0].get_title(loc="right") == "302 K"
+    assert plot.axes[1].get_title(loc="right") == "1.25 bar"
     assert len(plot.axes[0].lines) == 1
     assert len(plot.axes[1].lines) == 1
+    assert len(plot.axes[0].texts) == 0
+    assert len(plot.axes[1].texts) == 0
     assert len(plot.figure.legends) == 1
+
+
+def test_dashboard_uses_compact_latest_titles_for_multiple_files():
+    first = FakeDashboardEnergy()
+    second = FakeDashboardEnergy()
+    second.data["TEMPERATURE"] = np.array([301.0, 303.0, 304.0])
+    second.simulation_time = second.data["SIMULATION-TIME"]
+    app = FakeApp([first, second])
+    plot = PlotDashboard(app)
+
+    plot.redraw()
+
+    assert plot.axes[0].get_title(loc="right") == "302 | 304 K"
+
+
+def test_dashboard_multi_value_title_keeps_mixed_units():
+    app = FakeApp([FakeDashboardEnergy()])
+    plot = PlotDashboard(app)
+
+    title = plot._PlotDashboard__multi_value_title([
+        ValueReadoutEntry("a", 302.0, "#000000", "K"),
+        ValueReadoutEntry("b", 1.25, "#000000", "bar"),
+    ])
+
+    assert title == "302 K | 1.25 bar"
+
+
+def test_readout_value_formatting_uses_scientific_notation_selectively():
+    assert format_readout_value(302.123456, "K") == "302.12 K"
+    assert format_readout_value(0.0000123, "bar") == "1.2300e-05 bar"
+    assert format_readout_value(np.nan, "K") == "n/a K"
+
+
+def test_latest_value_label_uses_last_finite_value():
+    assert latest_value_label("Temperature", [300.0, np.nan, 302.0],
+                              "K") == "Temperature (302 K)"
+    assert latest_value_label("Temperature", [np.nan], "K") == "Temperature"
 
 
 def test_dashboard_double_click_opens_focused_parameter_plot():

--- a/tests/statistics/test_statistic.py
+++ b/tests/statistics/test_statistic.py
@@ -81,8 +81,7 @@ class TestStatistic:
         assert np.all(time == [1, 2, 3, 4, 5])
         assert np.allclose(
             self_correlation_mean,
-            [8.6666, 10, 11, 10, 8.6666],
-            rtol=1e-4,
+            [2, 2.5, 3, 3.5, 4],
         )
 
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
@@ -91,8 +90,7 @@ class TestStatistic:
         assert np.all(time == [1, 2, 3, 4, 5])
         assert np.allclose(
             self_correlation_mean,
-            [8.6666, 10, 11, 10, 8.6666],
-            rtol=1e-4,
+            [2, 2.5, 3, 3.5, 4],
         )
 
         energies2 = Reader(["tests/data/md-02.en"], MDEngineFormat.PQ).energies
@@ -101,8 +99,7 @@ class TestStatistic:
         assert np.all(time == [6, 7, 8, 9, 10])
         assert np.allclose(
             self_correlation_mean,
-            [63.6666, 65, 66, 65, 63.6666],
-            rtol=1e-4,
+            [7, 7.5, 8, 8.5, 9],
         )
 
     def test_self_correlation_mean_constant_data(self):
@@ -111,7 +108,7 @@ class TestStatistic:
                 [1, 2, 3, 4, 5], [2, 2, 2, 2, 2]))
 
         assert np.all(time == [1, 2, 3, 4, 5])
-        assert np.all(self_correlation_mean == [4, 4, 4, 4, 4])
+        assert np.all(self_correlation_mean == [2, 2, 2, 2, 2])
 
         energies = Reader(["tests/data/md-01.en"], MDEngineFormat.PQ).energies
 


### PR DESCRIPTION
## Summary
- Move focused plot latest values from endpoint annotations into compact legend labels.
- Keep dashboard latest values in subtle panel headers with compact multi-file formatting.
- Fix self-correlation mean so it stays on the original data scale instead of returning squared-magnitude values.

## Validation
- python -m pytest --cov=PQEnalyzer --cov-report=term-missing --cov-fail-under=100 -q
- python -m compileall PQEnalyzer
- git diff --check
- Visual QA script against example data confirmed no endpoint text labels and no dashboard header overlap.
