### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.12"
     - name: Install pypa/build
@@ -28,7 +28,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: python3 -m build
     - name: Store the distribution packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -47,7 +47,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
@@ -68,7 +68,7 @@ jobs:
         fetch-depth: 0
 
     - name: setup python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.12'
 
@@ -110,6 +110,7 @@ jobs:
 
     - name: Build CHANGELOG.md
       run: |
+        touch CHANGELOG.md
         git-changelog --sections ci,doc,feat,fix,perf,test -o CHANGELOG.md -c angular --in-place
 
     - name: Add CHANGELOG.md to commit
@@ -144,7 +145,7 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/


### PR DESCRIPTION
## Summary
- Update release artifact actions from v3 to v4.
- Update setup-python uses in the release workflow to v5.
- Ensure CHANGELOG.md exists before running git-changelog with --in-place.

## Validation
- Parsed .github/workflows/release.yml locally with Ruby YAML.
- Confirmed deprecated v3 artifact actions are no longer referenced in the release workflow.
