### PR TITLE
Make release workflow rerunnable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,8 @@ jobs:
         path: dist/
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        skip-existing: true
 
   github-release:
     name: >-
@@ -110,7 +112,9 @@ jobs:
 
     - name: Build CHANGELOG.md
       run: |
-        touch CHANGELOG.md
+        if [ ! -s CHANGELOG.md ]; then
+          printf '# Changelog\n\n<!-- insertion marker -->\n' > CHANGELOG.md
+        fi
         git-changelog --sections ci,doc,feat,fix,perf,test -o CHANGELOG.md -c angular --in-place
 
     - name: Add CHANGELOG.md to commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+<!-- insertion marker -->


### PR DESCRIPTION
## Summary
- Add a seeded CHANGELOG.md with the insertion marker required by git-changelog.
- Keep a fallback marker initialization in the release workflow.
- Make PyPI publishing skip existing files so a repaired tag workflow can be rerun safely.

## Validation
- Parsed .github/workflows/release.yml locally with Ruby YAML.
- Ran the same git-changelog --in-place command against a copied changelog file successfully.
- Confirmed deprecated artifact action versions are not referenced in the release workflow.
