### PR TITLE
Update release signing action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,7 +155,7 @@ jobs:
         path: dist/
 
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3.4.0
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
## Summary
- Update sigstore/gh-action-sigstore-python from v2.1.1 to v3.4.0.
- This avoids the deprecated upload-artifact v3 dependency that blocks the release signing job.

## Validation
- Parsed .github/workflows/release.yml locally with Ruby YAML.
- Confirmed the failing release log points to sigstore/gh-action-sigstore-python@v2.1.1 during action setup.
