### PR TITLE
Make changelog release step idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,11 @@ jobs:
         if [ ! -s CHANGELOG.md ]; then
           printf '# Changelog\n\n<!-- insertion marker -->\n' > CHANGELOG.md
         fi
-        git-changelog --sections ci,doc,feat,fix,perf,test -o CHANGELOG.md -c angular --in-place
+        if grep -Fq "releases/tag/$GITHUB_REF_NAME" CHANGELOG.md; then
+          echo "$GITHUB_REF_NAME already exists in CHANGELOG.md."
+        else
+          git-changelog --sections ci,doc,feat,fix,perf,test -o CHANGELOG.md -c angular --in-place
+        fi
 
     - name: Add CHANGELOG.md to commit
       run: |


### PR DESCRIPTION
## Summary
- Skip the release changelog generation step when the current tag already exists in CHANGELOG.md.
- This lets repaired tag workflows rerun after a partial release without failing on an existing changelog section.

## Validation
- Parsed .github/workflows/release.yml locally with Ruby YAML.
- Ran the skip condition locally with GITHUB_REF_NAME=v0.8.0 against the current CHANGELOG.md.
