### PR TITLE
Fix default GUI and plot refresh behavior

### DIFF
--- a/PQEnalyzer/__main__.py
+++ b/PQEnalyzer/__main__.py
@@ -15,6 +15,26 @@ from ._logging import configure_logging, get_logger
 
 
 logger = get_logger(__name__)
+APP_MODES = {"gui", "tui"}
+
+
+def _argv_with_default_mode(argv):
+    """
+    Default bare file arguments to GUI mode.
+
+    ``argparse`` subparsers normally treat the first positional argument as a
+    required mode. For the common GUI path, allow users to omit that mode and
+    pass files directly.
+    """
+
+    argv = list(argv)
+    if not argv:
+        return argv
+
+    if argv[0] in {"-h", "--help", "-v", "--version", *APP_MODES}:
+        return argv
+
+    return ["gui", *argv]
 
 
 def _add_input_arguments(parser):
@@ -89,7 +109,7 @@ def main():
     )
     _add_input_arguments(tui_parser)
 
-    args = parser.parse_args()
+    args = parser.parse_args(_argv_with_default_mode(sys.argv[1:]))
     configure_logging()
 
     from .readers import create_reader

--- a/PQEnalyzer/apps/app_layout.py
+++ b/PQEnalyzer/apps/app_layout.py
@@ -358,6 +358,8 @@ class StatisticsControlsView:
                               padx=10,
                               pady=5,
                               sticky="we")
+        self.window_size.bind("<KeyRelease>",
+                              self.__window_size_changed)
         self.window_size.configure(state="disabled")
 
         app.settings_frame = self.frame
@@ -405,6 +407,14 @@ class StatisticsControlsView:
             self.window_size,
             default="10",
         )
+
+    def __window_size_changed(self, event=None):
+        """
+        Redraw the selected plot when the running-average window changes.
+        """
+
+        if self.statistics_changed_callback is not None:
+            self.statistics_changed_callback()
 
     def __feature_command(self, feature):
         """

--- a/PQEnalyzer/energy_access.py
+++ b/PQEnalyzer/energy_access.py
@@ -140,10 +140,11 @@ def concatenate_series(energies: list, info_parameter: str) -> EnergySeries:
 
 def difference_series(energies: list, info_parameter: str) -> EnergySeries:
     """
-    Return the pointwise difference between two aligned energy series.
+    Return the pointwise difference between two energy series.
 
-    The returned values are ``first - second``. Simulation-time axes must match
-    exactly so the subtraction never hides shifted or differently sampled runs.
+    The returned values are ``first - second`` on shared simulation-time
+    values. This lets users compare runs that overlap without requiring both
+    files to start and stop at exactly the same step.
     """
 
     if len(energies) != 2:
@@ -154,16 +155,30 @@ def difference_series(energies: list, info_parameter: str) -> EnergySeries:
     second = series(energies[1], info_parameter)
 
     if (
-        first.time.shape != second.time.shape
-        or first.values.shape != second.values.shape
-        or not np.array_equal(first.time, second.time)
+        first.time.shape != first.values.shape
+        or second.time.shape != second.values.shape
     ):
         raise ValueError(
-            "Difference plotting requires matching simulation-time axes.")
+            "Difference plotting requires one value per simulation-time point."
+        )
+
+    _, first_indices, second_indices = np.intersect1d(
+        first.time,
+        second.time,
+        assume_unique=False,
+        return_indices=True,
+    )
+    if first_indices.size == 0:
+        raise ValueError(
+            "Difference plotting requires shared simulation-time values.")
+
+    first_order = np.argsort(first_indices)
+    first_indices = first_indices[first_order]
+    second_indices = second_indices[first_order]
 
     return EnergySeries(
-        time=first.time,
-        values=first.values - second.values,
+        time=first.time[first_indices],
+        values=first.values[first_indices] - second.values[second_indices],
         label=info_parameter,
         unit=first.unit,
     )

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -67,6 +67,7 @@ class FakeWidget:
         self.args = args
         self.kwargs = kwargs
         self.grid_calls = []
+        self.bind_calls = []
         self.configured_rows = []
         self.configured_columns = []
         self.value = False
@@ -95,6 +96,9 @@ class FakeWidget:
     def configure(self, *args, **kwargs):
         self.configure_args = args
         self.configure_kwargs = kwargs
+
+    def bind(self, *args, **kwargs):
+        self.bind_calls.append((args, kwargs))
 
 
 @pytest.fixture(autouse=True)
@@ -381,6 +385,31 @@ def test_statistics_control_callback_runs_after_difference_default(
     view.difference.kwargs["command"]()
 
     assert app.plot_main_data.value is True
+    assert calls == ["run"]
+
+
+def test_window_size_entry_runs_statistics_control_callback(monkeypatch):
+    calls = []
+    app = SimpleNamespace(
+        register=lambda callback: callback,
+        validate_number=lambda value: True,
+        toggle_entry_state=lambda event, entry, default="": None,
+        plot_main_data=FakeFlag(False),
+    )
+
+    monkeypatch.setattr(app_layout.ctk, "CTkFrame", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkLabel", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkCheckBox", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkEntry", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkFont",
+                        lambda *args, **kwargs: ("font", args, kwargs))
+
+    view = app_layout.StatisticsControlsView(app, lambda: calls.append("run"))
+    event_name, callback = view.window_size.bind_calls[0][0]
+
+    callback(None)
+
+    assert event_name == "<KeyRelease>"
     assert calls == ["run"]
 
 

--- a/tests/e2e/test_cli_modes.py
+++ b/tests/e2e/test_cli_modes.py
@@ -110,6 +110,35 @@ def test_gui_mode_starts_and_can_be_terminated():
 
 
 @pytest.mark.e2e
+def test_default_gui_mode_starts_and_can_be_terminated():
+    if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
+        pytest.skip("GUI e2e test requires a display; run with xvfb-run.")
+
+    process = subprocess.Popen(
+        [sys.executable, "-m", "PQEnalyzer", str(EXAMPLE_FILE)],
+        cwd=PROJECT_ROOT,
+        env=_subprocess_environment(),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    try:
+        time.sleep(2)
+
+        if process.poll() is not None:
+            stdout, stderr = process.communicate(timeout=5)
+            pytest.fail(
+                "Default GUI mode exited before the startup smoke window "
+                "elapsed.\n"
+                f"returncode={process.returncode}\n"
+                f"stdout={stdout}\n"
+                f"stderr={stderr}")
+    finally:
+        _terminate_process(process)
+
+
+@pytest.mark.e2e
 def test_gui_mode_starts_with_box_file_and_can_be_terminated():
     if sys.platform.startswith("linux") and not os.environ.get("DISPLAY"):
         pytest.skip("GUI e2e test requires a display; run with xvfb-run.")

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -295,7 +295,7 @@ def test_time_difference_subtracts_two_aligned_series():
     assert np.all(line.get_ydata() == [4, 4, 3])
 
 
-def test_time_difference_logs_misaligned_series(caplog):
+def test_time_difference_uses_shared_time_axis_values():
     first = FakeEnergy([5, 6, 7])
     second = FakeEnergy([1, 2, 4])
     second.simulation_time = np.array([2, 3, 4])
@@ -304,8 +304,24 @@ def test_time_difference_logs_misaligned_series(caplog):
 
     plot.statistics("PARAMETER")
 
+    assert len(plot.ax.lines) == 1
+    line = plot.ax.lines[0]
+    assert line.get_label() == "Difference (1 - 2) (5 unit)"
+    assert np.all(line.get_xdata() == [2, 3])
+    assert np.all(line.get_ydata() == [5, 5])
+
+
+def test_time_difference_logs_non_overlapping_series(caplog):
+    first = FakeEnergy([5, 6, 7])
+    second = FakeEnergy([1, 2, 4])
+    second.simulation_time = np.array([20, 30, 40])
+    app = FakeApp([first, second], difference=True)
+    plot = PlotTime(app)
+
+    plot.statistics("PARAMETER")
+
     assert len(plot.ax.lines) == 0
-    assert "matching simulation-time axes" in caplog.text
+    assert "shared simulation-time values" in caplog.text
 
 
 def test_time_self_correlation_mean_uses_data_scale():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,9 +33,34 @@ def test_cli_help_mentions_gui_and_tui_modes():
     assert result.returncode == 0
     assert "Traceback" not in result.stderr
     assert "{gui,tui}" in result.stdout
+    assert "gui" in result.stdout
+    assert "tui" in result.stdout
 
 
-def test_gui_mode_logs_reader_validation_errors():
+def test_default_gui_mode_logs_reader_validation_errors():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "PQEnalyzer",
+            "tests/data/md-01.en",
+            "tests/data/md-02.en",
+        ],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "ERROR: The energy files do not have the same info parameters" in (
+        result.stderr)
+
+
+def test_explicit_gui_mode_still_logs_reader_validation_errors():
     project_root = Path(__file__).resolve().parents[1]
 
     result = subprocess.run(
@@ -106,11 +131,42 @@ def test_cli_rejects_multiple_forced_input_formats():
     assert "not allowed with argument" in result.stderr
 
 
-def test_cli_requires_app_mode():
+def test_cli_defaults_to_gui_mode():
     project_root = Path(__file__).resolve().parents[1]
 
     result = subprocess.run(
-        [sys.executable, "-m", "PQEnalyzer", "examples/md-01.en"],
+        [
+            sys.executable,
+            "-m",
+            "PQEnalyzer",
+            "tests/data/md-01.en",
+            "tests/data/md-02.en",
+        ],
+        cwd=project_root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "invalid choice" not in result.stderr
+    assert "ERROR: The energy files do not have the same info parameters" in (
+        result.stderr)
+
+
+def test_default_gui_mode_accepts_input_format_flags():
+    project_root = Path(__file__).resolve().parents[1]
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "PQEnalyzer",
+            "--box",
+            "--qmcfc",
+            "examples/box-01.box",
+        ],
         cwd=project_root,
         capture_output=True,
         text=True,
@@ -119,4 +175,4 @@ def test_cli_requires_app_mode():
 
     assert result.returncode == 2
     assert "Traceback" not in result.stderr
-    assert "invalid choice" in result.stderr
+    assert "not allowed with argument" in result.stderr

--- a/tests/test_energy_access.py
+++ b/tests/test_energy_access.py
@@ -99,11 +99,33 @@ def test_difference_series_requires_exactly_two_files():
         difference_series([energy], "CUSTOM")
 
 
-def test_difference_series_requires_matching_time_axes():
-    first = CustomEnergy(time=[1.0, 2.0, 3.0])
-    second = CustomEnergy(time=[2.0, 3.0, 4.0])
+def test_difference_series_uses_shared_time_axis_values():
+    first = CustomEnergy(time=[1.0, 2.0, 3.0, 4.0],
+                         values=[10.0, 20.0, 30.0, 40.0])
+    second = CustomEnergy(time=[3.0, 4.0, 5.0],
+                          values=[1.0, 2.0, 3.0])
 
-    with pytest.raises(ValueError, match="matching simulation-time axes"):
+    energy_series = difference_series([first, second], "CUSTOM")
+
+    np.testing.assert_array_equal(energy_series.time, [3.0, 4.0])
+    np.testing.assert_array_equal(energy_series.values, [29.0, 38.0])
+
+
+def test_difference_series_requires_shared_time_axis_values():
+    first = CustomEnergy(time=[1.0, 2.0, 3.0])
+    second = CustomEnergy(time=[4.0, 5.0, 6.0])
+
+    with pytest.raises(ValueError, match="shared simulation-time values"):
+        difference_series([first, second], "CUSTOM")
+
+
+def test_difference_series_requires_values_aligned_to_time():
+    first = CustomEnergy(time=[1.0, 2.0, 3.0],
+                         values=[10.0, 20.0])
+    second = CustomEnergy(time=[1.0, 2.0, 3.0],
+                          values=[1.0, 2.0, 3.0])
+
+    with pytest.raises(ValueError, match="one value per simulation-time"):
         difference_series([first, second], "CUSTOM")
 
 
@@ -118,6 +140,22 @@ def test_difference_examples_have_nonconstant_difference():
     np.testing.assert_array_equal(energy_series.time,
                                   np.arange(6, 16))
     assert len(np.unique(np.round(energy_series.values, decimals=6))) > 1
+
+
+def test_difference_series_supports_box_reader_adapter():
+    energies = BoxReader([
+        "examples/box-01.box",
+        "examples/box-02.box",
+    ]).energies
+
+    energy_series = difference_series(energies, "BOX-X")
+
+    np.testing.assert_array_equal(energy_series.time,
+                                  np.array([1, 2, 3, 4, 5]))
+    np.testing.assert_allclose(
+        energy_series.values,
+        [0.1, 0.1, 0.1, -0.2, 0.2],
+    )
 
 
 def test_energy_access_supports_box_reader_adapter():


### PR DESCRIPTION
## Summary
- Default `pqenalyzer FILES...` to GUI mode while keeping explicit `gui` and `tui` modes.
- Compute difference plots over shared simulation-time values for overlapping `.en` and `.box` runs.
- Redraw the selected GUI plot when the running-average window-size entry changes.

## Issues
Closes #71
Closes #72
Closes #73

## Verification
- `python -m pytest tests/test_cli.py tests/test_energy_access.py tests/plots/test_gui_plots.py tests/apps/test_app.py tests/e2e/test_cli_modes.py::test_default_gui_mode_starts_and_can_be_terminated -q`
- `python -m pytest tests/e2e/test_cli_modes.py::test_tui_mode_opens_dashboard_and_chart_views -q`
- `python -m pytest --cov=PQEnalyzer --cov-report=term-missing --cov-fail-under=100 -q`
- `python -m compileall PQEnalyzer`
- `git diff --check`
