### PR TITLE
Fix GUI difference state and plot label sizing

### DIFF
--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -88,6 +88,7 @@ class App(ctk.CTk):
             self,
             self.__plot_button_event,
             self.__auto_refresh_control_event,
+            self.__statistics_control_event,
         )
         self.parameter_selector_view = ParameterSelectorView(
             self, self.__change_info_event)
@@ -343,9 +344,6 @@ class App(ctk.CTk):
 
         if self.__syncing_plot_controls:
             return None
-
-        if self.difference.get():
-            self.plot_main_data.set(True)
 
         if self.selected_plot is None:
             return None

--- a/PQEnalyzer/apps/app_layout.py
+++ b/PQEnalyzer/apps/app_layout.py
@@ -119,10 +119,12 @@ class PlotControlsView:
         app,
         plot_button_callback,
         auto_refresh_callback,
+        plot_options_callback=None,
     ):
         self.app = app
         self.plot_button_callback = plot_button_callback
         self.auto_refresh_callback = auto_refresh_callback
+        self.plot_options_callback = plot_options_callback
 
         self.frame = ctk.CTkFrame(app, width=200)
         self.frame.grid(row=2,
@@ -152,8 +154,9 @@ class PlotControlsView:
         self.no_data_checkbox = ctk.CTkCheckBox(
             master=self.frame,
             border_width=2,
-            text="No Data",
+            text="Hide Raw Data",
             variable=self.plot_main_data,
+            command=plot_options_callback,
         )
         self.no_data_checkbox.grid(row=0,
                                    column=0,

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -14,6 +14,7 @@ from .theme import apply_figure_theme, apply_matplotlib_theme
 
 
 logger = get_logger(__name__)
+SINGLE_PLOT_FIGURE_SIZE = (11, 7)
 
 
 class Plot(metaclass=ABCMeta):
@@ -63,7 +64,7 @@ class Plot(metaclass=ABCMeta):
         # create the plot
         self.palette = apply_matplotlib_theme(
             getattr(self.app, "appearance_mode", None))
-        self.figure = plt.figure(figsize=(9, 5.5))
+        self.figure = plt.figure(figsize=SINGLE_PLOT_FIGURE_SIZE)
         self.ax = self.figure.add_subplot(111)
         self.apply_theme()
         self.figure.canvas.mpl_connect("button_press_event",
@@ -119,8 +120,8 @@ class Plot(metaclass=ABCMeta):
         """
         Render a static plot for one info parameter.
 
-        Main data is plotted unless the "No Data" option is selected. Enabled
-        statistics are overlaid by the subclass implementation.
+        Main data is plotted unless the "Hide Raw Data" option is selected.
+        Enabled statistics are overlaid by the subclass implementation.
 
         Parameters
         ----------
@@ -262,7 +263,7 @@ class Plot(metaclass=ABCMeta):
             return False
 
         legend_options = {
-            "fontsize": "small",
+            "fontsize": "medium",
             "frameon": True,
         }
         legend_options.update(kwargs)

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -91,7 +91,6 @@ class PlotTime(Plot):
 
         if not self.show_legend(
             loc="best",
-            fontsize="x-small",
             framealpha=0.82,
             borderpad=0.35,
             labelspacing=0.28,

--- a/PQEnalyzer/plots/theme.py
+++ b/PQEnalyzer/plots/theme.py
@@ -6,6 +6,14 @@ import customtkinter as ctk
 import matplotlib
 from cycler import cycler
 
+PLOT_FONT_SIZES = {
+    "base": 12.0,
+    "title": 16.0,
+    "axis_label": 14.0,
+    "tick": 12.0,
+    "legend": 12.0,
+}
+
 
 LIGHT_PALETTE = {
     "figure.facecolor": "#f4f7fb",
@@ -93,23 +101,28 @@ def apply_matplotlib_theme(appearance_mode=None):
     palette = palette_for_appearance_mode(appearance_mode)
 
     matplotlib.rcParams.update({
+        "font.size": PLOT_FONT_SIZES["base"],
         "figure.facecolor": palette["figure.facecolor"],
         "axes.facecolor": palette["axes.facecolor"],
         "axes.edgecolor": palette["axes.edgecolor"],
         "axes.labelcolor": palette["axes.labelcolor"],
+        "axes.labelsize": PLOT_FONT_SIZES["axis_label"],
         "axes.grid": True,
         "axes.prop_cycle": cycler(color=palette["colors"]),
         "axes.titleweight": "semibold",
-        "axes.titlesize": "medium",
+        "axes.titlesize": PLOT_FONT_SIZES["title"],
         "lines.linewidth": 1.45,
         "lines.solid_capstyle": "round",
         "text.color": palette["text.color"],
         "xtick.color": palette["tick.color"],
+        "xtick.labelsize": PLOT_FONT_SIZES["tick"],
         "ytick.color": palette["tick.color"],
+        "ytick.labelsize": PLOT_FONT_SIZES["tick"],
         "grid.color": palette["grid.color"],
         "grid.alpha": 0.55,
         "legend.facecolor": palette["legend.facecolor"],
         "legend.edgecolor": palette["legend.edgecolor"],
+        "legend.fontsize": PLOT_FONT_SIZES["legend"],
         "legend.framealpha": 0.95,
         "savefig.facecolor": palette["figure.facecolor"],
     })
@@ -127,9 +140,14 @@ def apply_figure_theme(figure, axes, appearance_mode=None):
     figure.patch.set_facecolor(palette["figure.facecolor"])
     axes.set_facecolor(palette["axes.facecolor"])
     axes.grid(True, color=palette["grid.color"], alpha=0.55, linewidth=0.8)
-    axes.tick_params(colors=palette["tick.color"])
+    axes.tick_params(
+        colors=palette["tick.color"],
+        labelsize=PLOT_FONT_SIZES["tick"],
+    )
     axes.xaxis.label.set_color(palette["axes.labelcolor"])
+    axes.xaxis.label.set_size(PLOT_FONT_SIZES["axis_label"])
     axes.yaxis.label.set_color(palette["axes.labelcolor"])
+    axes.yaxis.label.set_size(PLOT_FONT_SIZES["axis_label"])
     for title in (
         axes.title,
         getattr(axes, "_left_title", None),
@@ -137,6 +155,7 @@ def apply_figure_theme(figure, axes, appearance_mode=None):
     ):
         if title is not None:
             title.set_color(palette["text.color"])
+            title.set_size(PLOT_FONT_SIZES["title"])
 
     for spine in axes.spines.values():
         spine.set_color(palette["axes.edgecolor"])
@@ -149,6 +168,8 @@ def apply_figure_theme(figure, axes, appearance_mode=None):
         legend.get_frame().set_alpha(0.95)
         for text in legend.get_texts():
             text.set_color(palette["text.color"])
+            text.set_size(PLOT_FONT_SIZES["legend"])
+        legend.get_title().set_size(PLOT_FONT_SIZES["legend"])
 
     for text in axes.texts:
         text.set_color(palette["text.color"])

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -281,10 +281,40 @@ def test_plot_controls_view_exposes_dashboard_button(monkeypatch):
 
     assert app.button_dashboard is view.dashboard_button
     assert app.button_dashboard.kwargs["text"] == "Live Monitor"
+    assert app.check_nodata is view.no_data_checkbox
+    assert app.check_nodata.kwargs["text"] == "Hide Raw Data"
     assert app.check_auto_refresh is view.auto_refresh_checkbox
     assert app.check_auto_refresh.kwargs["text"] == "Auto-Refresh"
     assert app.auto_refresh.value is True
     assert not hasattr(app, "button_refresh")
+
+
+def test_no_data_checkbox_runs_plot_options_callback(monkeypatch):
+    calls = []
+    app = SimpleNamespace(
+        register=lambda callback: callback,
+        validate_number=lambda value: True,
+        toggle_entry_state=lambda event, entry, default="": None,
+    )
+
+    monkeypatch.setattr(app_layout.ctk, "CTkFrame", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkCheckBox", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkEntry", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkLabel", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkButton", FakeWidget)
+    monkeypatch.setattr(app_layout.tkinter, "BooleanVar",
+                        lambda: FakeFlag(False))
+
+    view = app_layout.PlotControlsView(
+        app,
+        lambda event: event,
+        lambda: None,
+        lambda: calls.append("redraw"),
+    )
+
+    view.no_data_checkbox.kwargs["command"]()
+
+    assert calls == ["redraw"]
 
 
 def test_statistics_controls_view_exposes_plot_state_attributes(monkeypatch):
@@ -552,6 +582,36 @@ def test_statistics_controls_redraw_selected_plot(monkeypatch):
     assert calls[0].mean is True
     assert calls[0].running_average is True
     assert calls[0].window_size == "5"
+
+
+def test_statistics_controls_do_not_force_no_data_for_active_difference(
+        monkeypatch):
+    app = make_app()
+    app.mean = FakeFlag(False)
+    app.median = FakeFlag(False)
+    app.cummulative_average = FakeFlag(False)
+    app.self_correlation_mean = FakeFlag(False)
+    app.difference = FakeFlag(True)
+    app.running_average = FakeFlag(False)
+    app.plot_main_data = FakeFlag(False)
+    app.window_size = FakeEntry("")
+    calls = []
+
+    class SelectedPlot:
+        figure = SimpleNamespace(number=1)
+
+        def redraw(self, options=None):
+            calls.append(options)
+
+    app.selected_plot = SelectedPlot()
+    monkeypatch.setattr(app_module.plt, "get_fignums", lambda: [1])
+
+    app_module.App._App__statistics_control_event(app)
+
+    assert app.plot_main_data.value is False
+    assert len(calls) == 1
+    assert calls[0].difference is True
+    assert calls[0].plot_main is False
 
 
 def test_refresh_applies_controls_to_selected_plot(monkeypatch):

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -4,7 +4,9 @@ from types import SimpleNamespace
 
 from PQEnalyzer.plots.plot_dashboard import PlotDashboard
 from PQEnalyzer.plots.plot_histogram import PlotHistogram
+from PQEnalyzer.plots.plot import SINGLE_PLOT_FIGURE_SIZE
 from PQEnalyzer.plots.plot_time import PlotTime
+from PQEnalyzer.plots.theme import PLOT_FONT_SIZES
 from PQEnalyzer.plots.value_readout import (
     ValueReadoutEntry,
     format_readout_value,
@@ -209,6 +211,32 @@ def test_time_plot_renders_latest_values_in_legend_without_axis_labels():
     assert plot.ax.get_legend().get_title().get_text() == ""
 
 
+def test_time_plot_uses_readable_single_plot_typography():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])])
+    plot = PlotTime(app)
+    plot.info_parameter = "PARAMETER"
+
+    plot.plot_data()
+
+    assert plot.ax.get_title(loc="left") == "PARAMETER time series"
+    assert plot.ax._left_title.get_size() == PLOT_FONT_SIZES["title"]
+    assert plot.ax.xaxis.label.get_size() == PLOT_FONT_SIZES["axis_label"]
+    assert plot.ax.yaxis.label.get_size() == PLOT_FONT_SIZES["axis_label"]
+    assert plot.ax.get_xticklabels()[0].get_size() == PLOT_FONT_SIZES["tick"]
+    legend_text = plot.ax.get_legend().get_texts()[0]
+    assert legend_text.get_size() == PLOT_FONT_SIZES["legend"]
+
+
+def test_single_plot_uses_roomier_initial_window_size():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])])
+    plot = PlotTime(app)
+
+    np.testing.assert_allclose(
+        plot.figure.get_size_inches(),
+        SINGLE_PLOT_FIGURE_SIZE,
+    )
+
+
 def test_time_labels_use_time_series_title_and_parameter_axis():
     app = FakeApp([FakeEnergy([1, 2, 3, 4])])
     plot = PlotTime(app)
@@ -309,6 +337,45 @@ def test_time_difference_uses_shared_time_axis_values():
     assert line.get_label() == "Difference (1 - 2) (5 unit)"
     assert np.all(line.get_xdata() == [2, 3])
     assert np.all(line.get_ydata() == [5, 5])
+
+
+def test_time_difference_remains_active_when_raw_data_is_visible():
+    app = FakeApp(
+        [FakeEnergy([5, 6, 7]), FakeEnergy([1, 2, 4])],
+        difference=True,
+    )
+    app.plot_main_data.set(False)
+    plot = PlotTime(app)
+    plot.info_parameter = "PARAMETER"
+
+    plot.plot_data()
+
+    assert plot.ax.get_legend_handles_labels()[1] == [
+        "series-0.en (7 unit)",
+        "series-1.en (4 unit)",
+        "Difference (1 - 2) (3 unit)",
+    ]
+    assert len(plot.ax.lines) == 3
+    assert np.all(plot.ax.lines[-1].get_ydata() == [4, 4, 3])
+
+
+def test_time_difference_with_raw_data_uses_overlap_for_shifted_axes():
+    first = FakeEnergy([10, 20, 30, 40, 50])
+    second = FakeEnergy([3, 5, 7])
+    second.simulation_time = np.array([3, 5, 7])
+    app = FakeApp([first, second], difference=True)
+    app.plot_main_data.set(False)
+    plot = PlotTime(app)
+    plot.info_parameter = "PARAMETER"
+
+    plot.plot_data()
+
+    assert len(plot.ax.lines) == 3
+    np.testing.assert_array_equal(plot.ax.lines[0].get_xdata(),
+                                  [1, 2, 3, 4, 5])
+    np.testing.assert_array_equal(plot.ax.lines[1].get_xdata(), [3, 5, 7])
+    np.testing.assert_array_equal(plot.ax.lines[2].get_xdata(), [3, 5])
+    np.testing.assert_array_equal(plot.ax.lines[2].get_ydata(), [27, 45])
 
 
 def test_time_difference_logs_non_overlapping_series(caplog):

--- a/tests/plots/test_theme.py
+++ b/tests/plots/test_theme.py
@@ -21,6 +21,14 @@ def test_apply_matplotlib_theme_sets_dark_defaults():
         assert mpl.rcParams["text.color"] == palette["text.color"]
         assert mpl.rcParams["axes.prop_cycle"].by_key()["color"] == palette[
             "colors"]
+        assert mpl.rcParams["axes.titlesize"] == theme.PLOT_FONT_SIZES[
+            "title"]
+        assert mpl.rcParams["axes.labelsize"] == theme.PLOT_FONT_SIZES[
+            "axis_label"]
+        assert mpl.rcParams["xtick.labelsize"] == theme.PLOT_FONT_SIZES[
+            "tick"]
+        assert mpl.rcParams["legend.fontsize"] == theme.PLOT_FONT_SIZES[
+            "legend"]
 
 
 def test_apply_figure_theme_updates_existing_plot_elements():
@@ -44,9 +52,17 @@ def test_apply_figure_theme_updates_existing_plot_elements():
         assert axes.get_facecolor() == to_rgba(palette["axes.facecolor"])
         assert axes.xaxis.label.get_color() == palette["axes.labelcolor"]
         assert axes.yaxis.label.get_color() == palette["axes.labelcolor"]
+        assert axes.xaxis.label.get_size() == theme.PLOT_FONT_SIZES[
+            "axis_label"]
+        assert axes.yaxis.label.get_size() == theme.PLOT_FONT_SIZES[
+            "axis_label"]
+        assert axes.get_xticklabels()[0].get_size() == theme.PLOT_FONT_SIZES[
+            "tick"]
         assert axes.get_title(loc="left") == "Energy trace"
         assert axes._left_title.get_color() == palette["text.color"]
-        assert axes.get_legend().get_texts()[0].get_color() == palette[
-            "text.color"]
+        assert axes._left_title.get_size() == theme.PLOT_FONT_SIZES["title"]
+        legend_text = axes.get_legend().get_texts()[0]
+        assert legend_text.get_color() == palette["text.color"]
+        assert legend_text.get_size() == theme.PLOT_FONT_SIZES["legend"]
         assert axes.texts[0].get_color() == palette["text.color"]
         assert axes.texts[0].get_bbox_patch().get_alpha() == 0.85


### PR DESCRIPTION
## Summary
- Keep GUI difference mode active when the Hide Raw Data option is toggled, so users can hide raw data by default or show raw series plus the difference overlay.
- Rename the raw-series toggle from No Data to Hide Raw Data to make the automatic behavior clear.
- Increase readable typography for single Matplotlib GUI plots: title, axes, ticks, and legends.
- Start focused time and histogram plot windows at a roomier 11 x 7 inch size.
- Add regression coverage for shifted/unequal simulation-time axes, GUI state updates, plot font sizing, and initial plot size.

## Validation
- python -m pytest tests/apps/test_app.py tests/plots/test_gui_plots.py tests/plots/test_theme.py tests/test_energy_access.py -q
- python -m pytest tests/apps/test_app.py tests/plots/test_gui_plots.py tests/test_energy_access.py -q
- python -m pytest tests/plots/test_theme.py tests/plots/test_gui_plots.py -q
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing
- python -m pytest -m e2e -q
- python -m compileall -q PQEnalyzer tests
- git diff --check
- Rendered sample difference plots and checked the resulting line count, font sizes, and initial figure size.

Fixes #75
Fixes #76
