### PR TITLE
Fix dashboard focus parameter selection

### DIFF
--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -316,7 +316,6 @@ class App(ctk.CTk):
         Open a focused time-series plot for one dashboard parameter.
         """
 
-        self.__change_info_event(info_parameter)
         plot = PlotTime(self)
         self.list_of_plots.append(plot)
 

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -444,6 +444,21 @@ def test_plot_button_runs_dashboard(monkeypatch):
     assert app.selected_plot is None
 
 
+def test_dashboard_focus_plot_does_not_change_selected_dropdown_parameter(
+        monkeypatch):
+    app = make_app(auto_refresh=False)
+    monkeypatch.setattr(app_module, "PlotTime", DummyPlot)
+
+    app_module.App.open_focus_plot(app, "PRESSURE")
+    app_module.App._App__plot_button_event(app, 0)
+
+    assert [plot.calls for plot in DummyPlot.instances] == [
+        [("simple", "PRESSURE")],
+        [("simple", "TEMPERATURE")],
+    ]
+    assert app._App__selected_info == "TEMPERATURE"
+
+
 def test_plot_button_rejects_unknown_event():
     with pytest.raises(ValueError, match="Unknown plot event"):
         app_module.App._App__plot_button_event(make_app(), 3)


### PR DESCRIPTION
## Summary
- Keep dashboard focused plots independent from the GUI parameter drop-down selection.
- Fix the bug where opening a focused dashboard panel silently changed the next Plot button target.
- Add a regression test for the reported flow: focus a non-first dashboard parameter, then plot using the unchanged drop-down selection.

## Root cause
The dashboard focus path reused the same selected-parameter state as the drop-down. Because the drop-down widget was not updated, the visible selection and the internal plot target diverged after opening a focused dashboard panel.

## Validation
- python -m pytest tests/apps/test_app.py::test_dashboard_focus_plot_does_not_change_selected_dropdown_parameter -q
- python -m pytest tests/apps/test_app.py::test_dashboard_focus_plot_does_not_change_selected_dropdown_parameter tests/apps/test_app.py tests/plots/test_gui_plots.py -q
- python -m pytest -m "not benchmark and not e2e" --cov=PQEnalyzer --cov-report=term-missing
- python -m pytest -m e2e -q
- python -m compileall -q PQEnalyzer tests
- git diff --check

Fixes #78
