### PR TITLE
Allow missing parameters across input files

### DIFF
--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -8,6 +8,7 @@ import customtkinter as ctk
 import matplotlib.pyplot as plt
 
 from .._logging import get_logger
+from ..energy_access import available_parameters
 from ..plots import PlotDashboard, PlotTime, PlotHistogram
 from ..plots.features import PLOT_FEATURES
 from ..plots.options import PlotOptions
@@ -56,9 +57,10 @@ class App(ctk.CTk):
         configure_window(self)
 
         self.reader = reader
-        self.info = [
-            *self.reader.energies[0].info
-        ][1:]
+        self.info = available_parameters(
+            self.reader.energies,
+            include_time=False,
+        )
 
         self.list_of_plots = []
         self.selected_plot = None

--- a/PQEnalyzer/apps/tui.py
+++ b/PQEnalyzer/apps/tui.py
@@ -13,7 +13,11 @@ from textual.containers import Horizontal, Vertical
 from textual.widgets import DataTable, Footer, Header, Sparkline, Static
 
 from .._logging import get_logger
-from ..energy_access import concatenate_series, simulation_time
+from ..energy_access import (
+    available_parameters,
+    concatenate_series,
+    simulation_time,
+)
 from ..plots.features import (
     PLOT_FEATURES,
     PLOT_FEATURES_BY_KEY,
@@ -295,7 +299,10 @@ class TuiApp(App):
 
         super().__init__()
         self.reader = reader
-        self.info = [*self.reader.energies[0].info][1:]
+        self.info = available_parameters(
+            self.reader.energies,
+            include_time=False,
+        )
         self.watch_enabled = watch
         self.file_watcher = None
         self.last_refresh = None

--- a/PQEnalyzer/energy_access.py
+++ b/PQEnalyzer/energy_access.py
@@ -29,6 +29,44 @@ PARAMETER_ATTRIBUTES = {
 # Mapping from PQ info labels to PQAnalysis ``Energy`` attribute names.
 
 
+def has_parameter(energy, info_parameter: str) -> bool:
+    """
+    Return whether one parsed energy-like object exposes a parameter.
+    """
+
+    return info_parameter in getattr(energy, "info", {})
+
+
+def energies_with_parameter(energies: list, info_parameter: str) -> list:
+    """
+    Return only the loaded energy-like objects that expose a parameter.
+    """
+
+    return [
+        energy for energy in energies
+        if has_parameter(energy, info_parameter)
+    ]
+
+
+def available_parameters(energies: list, *, include_time: bool = True) -> list:
+    """
+    Return the ordered union of parameters exposed by loaded files.
+    """
+
+    parameters = []
+    seen = set()
+    for energy in energies:
+        for parameter in getattr(energy, "info", {}):
+            if not include_time and parameter == "SIMULATION-TIME":
+                continue
+            if parameter in seen:
+                continue
+            seen.add(parameter)
+            parameters.append(parameter)
+
+    return parameters
+
+
 @dataclass(frozen=True)
 class EnergySeries:
     """
@@ -61,6 +99,10 @@ def parameter_values(energy, info_parameter: str) -> np.ndarray:
     ``Energy`` object.
     """
 
+    if not has_parameter(energy, info_parameter):
+        raise ValueError(
+            f"Parameter {info_parameter} is not present in this energy file.")
+
     attribute = PARAMETER_ATTRIBUTES.get(info_parameter)
     if attribute is not None and hasattr(energy, attribute):
         return np.asarray(getattr(energy, attribute))
@@ -76,12 +118,29 @@ def parameter_unit(energy, info_parameter: str) -> str:
     from the same source as the values when possible.
     """
 
+    if not has_parameter(energy, info_parameter):
+        raise ValueError(
+            f"Parameter {info_parameter} is not present in this energy file.")
+
     attribute = PARAMETER_ATTRIBUTES.get(info_parameter)
     unit_attribute = f"{attribute}_unit"
     if attribute is not None and hasattr(energy, unit_attribute):
         return getattr(energy, unit_attribute)
 
     return energy.units[info_parameter]
+
+
+def parameter_unit_for_energies(energies: list, info_parameter: str) -> str:
+    """
+    Return a parameter unit from the first loaded file that exposes it.
+    """
+
+    matching_energies = energies_with_parameter(energies, info_parameter)
+    if not matching_energies:
+        raise ValueError(
+            f"Parameter {info_parameter} is not present in any input file.")
+
+    return parameter_unit(matching_energies[0], info_parameter)
 
 
 def simulation_time(energy) -> np.ndarray:
@@ -115,26 +174,40 @@ def concatenate_time(energies: list) -> np.ndarray:
 
 def concatenate_parameter(energies: list, info_parameter: str) -> np.ndarray:
     """
-    Concatenate one parameter from multiple energy files in reader order.
+    Concatenate one parameter from files that expose it in reader order.
     """
 
+    matching_energies = energies_with_parameter(energies, info_parameter)
+    if not matching_energies:
+        raise ValueError(
+            f"Parameter {info_parameter} is not present in any input file.")
+
     return np.concatenate(
-        [parameter_values(energy, info_parameter) for energy in energies])
+        [
+            parameter_values(energy, info_parameter)
+            for energy in matching_energies
+        ])
 
 
 def concatenate_series(energies: list, info_parameter: str) -> EnergySeries:
     """
     Return one normalized parameter series across multiple energy files.
 
-    Reader compatibility validation guarantees all files share the same unit,
-    so the returned series can safely use the first file's unit.
+    Files that do not expose the selected parameter are omitted. Reader
+    compatibility validation guarantees common parameters use the same unit, so
+    the returned series can safely use the first matching file's unit.
     """
 
+    matching_energies = energies_with_parameter(energies, info_parameter)
+    if not matching_energies:
+        raise ValueError(
+            f"Parameter {info_parameter} is not present in any input file.")
+
     return EnergySeries(
-        time=concatenate_time(energies),
+        time=concatenate_time(matching_energies),
         values=concatenate_parameter(energies, info_parameter),
         label=info_parameter,
-        unit=parameter_unit(energies[0], info_parameter),
+        unit=parameter_unit(matching_energies[0], info_parameter),
     )
 
 
@@ -150,6 +223,11 @@ def difference_series(energies: list, info_parameter: str) -> EnergySeries:
     if len(energies) != 2:
         raise ValueError(
             "Difference plotting requires exactly two input files.")
+
+    if not all(has_parameter(energy, info_parameter) for energy in energies):
+        raise ValueError(
+            "Difference plotting requires the selected parameter in both "
+            "input files.")
 
     first = series(energies[0], info_parameter)
     second = series(energies[1], info_parameter)

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -6,7 +6,7 @@ from abc import abstractmethod, ABCMeta
 import matplotlib.pyplot as plt
 import matplotlib.animation as animation
 
-from ..energy_access import parameter_unit
+from ..energy_access import parameter_unit_for_energies
 from .._logging import get_logger
 from .features import PLOT_FEATURES
 from .options import PlotOptions
@@ -275,7 +275,10 @@ class Plot(metaclass=ABCMeta):
         Return a parameter label including the reader-reported unit.
         """
 
-        unit = parameter_unit(self.reader.energies[0], info_parameter)
+        unit = parameter_unit_for_energies(
+            self.reader.energies,
+            info_parameter,
+        )
         return f"{info_parameter} / {unit}"
 
     def style_single_plot(

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -9,7 +9,11 @@ import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 
 from .._logging import get_logger
-from ..energy_access import parameter_unit, series
+from ..energy_access import (
+    has_parameter,
+    parameter_unit_for_energies,
+    series,
+)
 from .labels import unique_path_labels
 from .theme import (
     apply_figure_theme,
@@ -144,6 +148,9 @@ class PlotDashboard:
         """
 
         for index, energy in enumerate(self.reader.energies):
+            if not has_parameter(energy, parameter):
+                continue
+
             energy_series = series(energy, parameter)
             line = ax.plot(
                 energy_series.time,
@@ -164,7 +171,7 @@ class PlotDashboard:
         Label one dashboard axis compactly.
         """
 
-        unit = parameter_unit(self.reader.energies[0], parameter)
+        unit = parameter_unit_for_energies(self.reader.energies, parameter)
         palette = palette_for_appearance_mode(
             getattr(self.app, "appearance_mode", None))
         ax.set_title(f"{parameter} / {unit}", fontsize=9, loc="left", pad=6)
@@ -190,7 +197,7 @@ class PlotDashboard:
         if len(values) == 0:
             return
 
-        unit = parameter_unit(self.reader.energies[0], parameter)
+        unit = parameter_unit_for_energies(self.reader.energies, parameter)
         self.latest_values.setdefault(parameter, []).append(
             ValueReadoutEntry(
                 label=label,

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -7,6 +7,7 @@ import signal
 
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
+import numpy as np
 
 from .._logging import get_logger
 from ..energy_access import (
@@ -132,6 +133,8 @@ class PlotDashboard:
             self.__plot_parameter(ax, parameter, labels)
             self.__label_axis(ax, parameter, index)
             self.__style_axis(ax, parameter)
+
+        self.__apply_shared_x_limits()
 
         for ax in self.axes[len(self.parameters):]:
             ax.set_visible(False)
@@ -271,6 +274,30 @@ class PlotDashboard:
             return
 
         logger.warning("No data to plot.")
+
+    def __apply_shared_x_limits(self):
+        """
+        Apply the full plotted time range to every dashboard panel.
+        """
+
+        x_values = []
+        for ax in self.axes[:len(self.parameters)]:
+            for line in ax.lines:
+                values = np.asarray(line.get_xdata(), dtype=float)
+                x_values.extend(values[np.isfinite(values)])
+
+        if not x_values:
+            return
+
+        lower = min(x_values)
+        upper = max(x_values)
+        if lower == upper:
+            margin = max(abs(lower) * 0.05, 0.5)
+            lower -= margin
+            upper += margin
+
+        for ax in self.axes[:len(self.parameters)]:
+            ax.set_xlim(lower, upper)
 
     def __safe_read_last(self):
         """

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -19,6 +19,7 @@ from .theme import (
     apply_figure_theme,
     apply_matplotlib_theme,
     palette_for_appearance_mode,
+    series_color,
 )
 from .value_readout import ValueReadoutEntry, format_readout_value
 
@@ -135,7 +136,7 @@ class PlotDashboard:
         for ax in self.axes[len(self.parameters):]:
             ax.set_visible(False)
 
-        self.__show_legend()
+        self.__show_legend(labels)
         self.__set_title()
         self.figure.tight_layout(rect=(0, 0.03, 1, 0.92),
                                  h_pad=1.0,
@@ -156,6 +157,10 @@ class PlotDashboard:
                 energy_series.time,
                 energy_series.values,
                 label=labels[index],
+                color=series_color(
+                    index,
+                    getattr(self.app, "appearance_mode", None),
+                ),
                 linewidth=1.45,
                 alpha=0.92,
             )[0]
@@ -239,24 +244,31 @@ class PlotDashboard:
 
         return " | ".join(entry.formatted_value for entry in entries)
 
-    def __show_legend(self):
+    def __show_legend(self, file_labels):
         """
-        Draw one shared legend for the dashboard.
+        Draw one shared legend containing every plotted input file.
         """
 
+        handles_by_label = {}
         for ax in self.axes:
             handles, labels = ax.get_legend_handles_labels()
-            if labels:
-                self.figure.legend(
-                    handles,
-                    labels,
-                    loc="upper right",
-                    bbox_to_anchor=(0.995, 0.985),
-                    ncol=min(4, len(labels)),
-                    fontsize="small",
-                    frameon=True,
-                )
-                return
+            for handle, label in zip(handles, labels):
+                handles_by_label.setdefault(label, handle)
+
+        labels = [
+            label for label in file_labels if label in handles_by_label
+        ]
+        if labels:
+            self.figure.legend(
+                [handles_by_label[label] for label in labels],
+                labels,
+                loc="upper right",
+                bbox_to_anchor=(0.995, 0.985),
+                ncol=min(4, len(labels)),
+                fontsize="small",
+                frameon=True,
+            )
+            return
 
         logger.warning("No data to plot.")
 

--- a/PQEnalyzer/plots/plot_histogram.py
+++ b/PQEnalyzer/plots/plot_histogram.py
@@ -4,7 +4,7 @@ Histogram/KDE plotting for PQ energy parameters.
 from scipy.stats import gaussian_kde
 import numpy as np
 
-from ..energy_access import parameter_values
+from ..energy_access import has_parameter, parameter_values
 from .._logging import get_logger
 from .features import iter_histogram_guides
 from .labels import unique_path_labels
@@ -59,6 +59,9 @@ class PlotHistogram(Plot):
 
         labels = unique_path_labels(self.reader.filenames)
         for i, energy in enumerate(self.reader.energies):
+            if not has_parameter(energy, info_parameter):
+                continue
+
             data = parameter_values(energy, info_parameter)
 
             # check if zero data

--- a/PQEnalyzer/plots/plot_histogram.py
+++ b/PQEnalyzer/plots/plot_histogram.py
@@ -9,6 +9,7 @@ from .._logging import get_logger
 from .features import iter_histogram_guides
 from .labels import unique_path_labels
 from .plot import Plot
+from .theme import series_color
 
 
 logger = get_logger(__name__)
@@ -83,6 +84,10 @@ class PlotHistogram(Plot):
                 x,
                 y,
                 label=f"{labels[i]} KDE",
+                color=series_color(
+                    i,
+                    getattr(self.app, "appearance_mode", None),
+                ),
                 linewidth=1.8,
                 alpha=0.95,
                 zorder=3,

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -2,7 +2,12 @@
 Time-series plotting for PQ energy parameters.
 """
 
-from ..energy_access import parameter_unit, series
+from ..energy_access import (
+    has_parameter,
+    parameter_unit,
+    parameter_unit_for_energies,
+    series,
+)
 from .._logging import get_logger
 from .features import iter_time_series_overlays
 from .labels import unique_path_labels
@@ -57,6 +62,9 @@ class PlotTime(Plot):
 
         labels = unique_path_labels(self.reader.filenames)
         for i, energy in enumerate(self.reader.energies):
+            if not has_parameter(energy, info_parameter):
+                continue
+
             energy_series = series(energy, info_parameter)
             unit = parameter_unit(energy, info_parameter)
             self.ax.plot(
@@ -115,7 +123,10 @@ class PlotTime(Plot):
         """
 
         try:
-            unit = parameter_unit(self.reader.energies[0], info_parameter)
+            unit = parameter_unit_for_energies(
+                self.reader.energies,
+                info_parameter,
+            )
             for overlay in iter_time_series_overlays(
                 self.reader.energies,
                 info_parameter,

--- a/PQEnalyzer/plots/plot_time.py
+++ b/PQEnalyzer/plots/plot_time.py
@@ -12,6 +12,7 @@ from .._logging import get_logger
 from .features import iter_time_series_overlays
 from .labels import unique_path_labels
 from .plot import Plot
+from .theme import series_color
 from .value_readout import latest_value_label
 
 
@@ -72,6 +73,10 @@ class PlotTime(Plot):
                 energy_series.values,
                 label=latest_value_label(labels[i], energy_series.values,
                                          unit),
+                color=series_color(
+                    i,
+                    getattr(self.app, "appearance_mode", None),
+                ),
                 linewidth=1.6,
                 alpha=0.92,
                 zorder=2,

--- a/PQEnalyzer/plots/terminal_chart.py
+++ b/PQEnalyzer/plots/terminal_chart.py
@@ -4,7 +4,7 @@ Terminal chart rendering for the Textual TUI.
 
 import plotext as plt
 
-from ..energy_access import parameter_unit, series
+from ..energy_access import has_parameter, parameter_unit_for_energies, series
 from .features import iter_time_series_overlays
 from .labels import unique_path_labels
 
@@ -21,6 +21,9 @@ def build_terminal_chart(reader, info_parameter, width=88, height=22,
     if options is None or not options.plot_main:
         labels = unique_path_labels(reader.filenames)
         for index, energy in enumerate(reader.energies):
+            if not has_parameter(energy, info_parameter):
+                continue
+
             energy_series = series(energy, info_parameter)
             plt.plot(
                 energy_series.time,
@@ -41,7 +44,7 @@ def build_terminal_chart(reader, info_parameter, width=88, height=22,
                 label=overlay.label,
             )
 
-    unit = parameter_unit(reader.energies[0], info_parameter)
+    unit = parameter_unit_for_energies(reader.energies, info_parameter)
     plt.title(f"{info_parameter} / {unit}")
     plt.xlabel("Simulation Time")
     plt.ylabel(f"{info_parameter} / {unit}")

--- a/PQEnalyzer/plots/terminal_chart.py
+++ b/PQEnalyzer/plots/terminal_chart.py
@@ -7,6 +7,7 @@ import plotext as plt
 from ..energy_access import has_parameter, parameter_unit_for_energies, series
 from .features import iter_time_series_overlays
 from .labels import unique_path_labels
+from .theme import series_rgb
 
 
 def build_terminal_chart(reader, info_parameter, width=88, height=22,
@@ -29,19 +30,25 @@ def build_terminal_chart(reader, info_parameter, width=88, height=22,
                 energy_series.time,
                 energy_series.values,
                 label=labels[index],
+                color=series_rgb(index, "Dark"),
             )
 
     if options is not None:
-        for overlay in iter_time_series_overlays(
+        overlays = iter_time_series_overlays(
             reader.energies,
             info_parameter,
             options,
             window_policy="clamp",
-        ):
+        )
+        for overlay_index, overlay in enumerate(overlays):
             plt.plot(
                 overlay.time,
                 overlay.values,
                 label=overlay.label,
+                color=series_rgb(
+                    len(reader.energies) + overlay_index,
+                    "Dark",
+                ),
             )
 
     unit = parameter_unit_for_energies(reader.energies, info_parameter)

--- a/PQEnalyzer/plots/theme.py
+++ b/PQEnalyzer/plots/theme.py
@@ -93,6 +93,24 @@ def palette_for_appearance_mode(appearance_mode=None):
     return LIGHT_PALETTE
 
 
+def series_color(index, appearance_mode=None):
+    """
+    Return the stable plot color assigned to one input-file index.
+    """
+
+    colors = palette_for_appearance_mode(appearance_mode)["colors"]
+    return colors[index % len(colors)]
+
+
+def series_rgb(index, appearance_mode=None):
+    """
+    Return one indexed series color as an RGB tuple for terminal plots.
+    """
+
+    color = series_color(index, appearance_mode).lstrip("#")
+    return tuple(int(color[offset:offset + 2], 16) for offset in (0, 2, 4))
+
+
 def apply_matplotlib_theme(appearance_mode=None):
     """
     Apply a CustomTkinter-aligned palette to matplotlib defaults.

--- a/PQEnalyzer/readers/reader.py
+++ b/PQEnalyzer/readers/reader.py
@@ -15,7 +15,7 @@ class Reader:
 
     PQAnalysis owns the energy-file parsing. This wrapper keeps the
     PQEnalyzer-specific behavior around multi-file reads: every selected file
-    must expose the same parameter mapping and units before plotting.
+    must use compatible units for parameters that appear in more than one file.
 
     Attributes
     ----------
@@ -119,23 +119,26 @@ class Reader:
 
     def __validate_energy_compatibility(self, energies):
         """
-        Check if all energy files expose the same parameters and units.
+        Check if shared energy parameters use matching units.
 
-        Multi-file plots assume each parameter label refers to the same column
-        and unit in every file. Rejecting mismatches here keeps plotting and
-        statistics code simple.
+        Multi-file plots can omit files that do not expose a selected
+        parameter. If two files expose the same parameter label, that label
+        must still use the same unit in both files.
         """
 
-        reference_info = energies[0].info
-        reference_units = energies[0].units
+        units_by_parameter = {}
+        reference_filename_by_parameter = {}
 
-        for index, energy in enumerate(energies[1:], start=1):
-            if energy.info != reference_info:
-                raise ValueError(
-                    "The energy files do not have the same info parameters: "
-                    f"{self.filenames[0]} and {self.filenames[index]}.")
+        for filename, energy in zip(self.filenames, energies):
+            for parameter, unit in energy.units.items():
+                if parameter not in units_by_parameter:
+                    units_by_parameter[parameter] = unit
+                    reference_filename_by_parameter[parameter] = filename
+                    continue
 
-            if energy.units != reference_units:
-                raise ValueError(
-                    "The energy files do not have the same units: "
-                    f"{self.filenames[0]} and {self.filenames[index]}.")
+                if unit != units_by_parameter[parameter]:
+                    reference_filename = reference_filename_by_parameter[
+                        parameter]
+                    raise ValueError(
+                        "The energy files do not have the same units for "
+                        f"{parameter}: {reference_filename} and {filename}.")

--- a/README.md
+++ b/README.md
@@ -114,9 +114,10 @@ PQEnalyzer also reads PQ box files through `PQAnalysis`. Box files are expected
 to contain `step x y z alpha beta gamma` columns. The plotted parameters are
 `BOX-X`, `BOX-Y`, `BOX-Z`, `ALPHA`, `BETA`, `GAMMA`, and `BOX-VOLUME`.
 
-When multiple files are supplied, their parsed parameter mappings and units must
-match. Files with different columns or incompatible units are rejected before
-plotting.
+When multiple files are supplied, common parameters are plotted together.
+Parameters that are present in only some files are still selectable and are
+plotted from the files that contain them. Shared parameters must use matching
+units; incompatible units are rejected before plotting.
 
 Difference plots require exactly two loaded files. Values are calculated as
 `file 1 - file 2` on shared simulation-time values. PQEnalyzer does not

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -44,6 +44,15 @@ class FakeEnergy:
         self.simulation_time = np.arange(1, len(values) + 1)
 
 
+class FakeMissingParameterEnergy:
+
+    def __init__(self):
+        self.info = {"OTHER": "OTHER"}
+        self.units = {"OTHER": "other-unit"}
+        self.data = {"OTHER": np.array([10.0, 11.0, 12.0])}
+        self.simulation_time = np.array([1, 2, 3])
+
+
 class FakeDashboardEnergy:
 
     def __init__(self):
@@ -150,6 +159,19 @@ def test_histogram_disambiguates_duplicate_filenames():
         "run-b/md.en KDE",
     ]
     assert len(plot.ax.collections) == 2
+
+
+def test_histogram_skips_files_missing_selected_parameter():
+    app = FakeApp([
+        FakeMissingParameterEnergy(),
+        FakeEnergy([1, 2, 3, 4]),
+    ])
+    plot = PlotHistogram(app)
+
+    plot.main_data("PARAMETER")
+
+    assert plot.ax.get_legend_handles_labels()[1] == ["series-1.en KDE"]
+    assert len(plot.ax.collections) == 1
 
 
 def test_histogram_statistics_draw_single_mean_and_median_lines():
@@ -262,6 +284,21 @@ def test_time_main_data_disambiguates_duplicate_filenames():
         "run-a/md.en (4 unit)",
         "run-b/md.en (5 unit)",
     ]
+
+
+def test_time_main_data_skips_files_missing_selected_parameter():
+    app = FakeApp([
+        FakeMissingParameterEnergy(),
+        FakeEnergy([1, 2, 3, 4]),
+    ])
+    plot = PlotTime(app)
+
+    plot.main_data("PARAMETER")
+
+    assert plot.ax.get_legend_handles_labels()[1] == [
+        "series-1.en (4 unit)"
+    ]
+    assert len(plot.ax.lines) == 1
 
 
 def test_running_average_rejects_invalid_window_size_without_crashing(caplog):

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -501,6 +501,41 @@ def test_dashboard_keeps_file_colors_when_a_parameter_is_missing():
     ]
 
 
+def test_dashboard_shares_full_time_range_across_parameters():
+    first = FakeDashboardEnergy()
+    first.info.pop("TEMPERATURE")
+    first.units.pop("TEMPERATURE")
+    first.data.pop("TEMPERATURE")
+    first.simulation_time = np.array([0.0, 1.0, 2.0])
+
+    second = FakeDashboardEnergy()
+    second.info.pop("PRESSURE")
+    second.units.pop("PRESSURE")
+    second.data.pop("PRESSURE")
+    second.simulation_time = np.array([5.0, 6.0, 7.0])
+
+    plot = PlotDashboard(FakeApp([first, second]))
+
+    plot.redraw()
+
+    np.testing.assert_allclose(plot.axes[0].get_xlim(), (0.0, 7.0))
+    np.testing.assert_allclose(plot.axes[1].get_xlim(), (0.0, 7.0))
+
+
+def test_dashboard_expands_shared_range_for_single_time_value():
+    energy = FakeDashboardEnergy()
+    energy.simulation_time = np.array([2.0])
+    for parameter in ("TEMPERATURE", "PRESSURE"):
+        energy.data[parameter] = energy.data[parameter][:1]
+
+    plot = PlotDashboard(FakeApp([energy]))
+
+    plot.redraw()
+
+    np.testing.assert_allclose(plot.axes[0].get_xlim(), (1.5, 2.5))
+    np.testing.assert_allclose(plot.axes[1].get_xlim(), (1.5, 2.5))
+
+
 def test_dashboard_multi_value_title_keeps_mixed_units():
     app = FakeApp([FakeDashboardEnergy()])
     plot = PlotDashboard(app)

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -6,7 +6,7 @@ from PQEnalyzer.plots.plot_dashboard import PlotDashboard
 from PQEnalyzer.plots.plot_histogram import PlotHistogram
 from PQEnalyzer.plots.plot import SINGLE_PLOT_FIGURE_SIZE
 from PQEnalyzer.plots.plot_time import PlotTime
-from PQEnalyzer.plots.theme import PLOT_FONT_SIZES
+from PQEnalyzer.plots.theme import PLOT_FONT_SIZES, series_color
 from PQEnalyzer.plots.value_readout import (
     ValueReadoutEntry,
     format_readout_value,
@@ -142,6 +142,7 @@ def test_histogram_skips_constant_series_and_plots_remaining_data(caplog):
 
     assert plot.ax.get_legend_handles_labels()[1] == ["series-1.en KDE"]
     assert len(plot.ax.collections) == 1
+    assert plot.ax.lines[0].get_color() == series_color(1, "Light")
     assert "Data zero. No histogram available." in caplog.text
 
 
@@ -172,6 +173,7 @@ def test_histogram_skips_files_missing_selected_parameter():
 
     assert plot.ax.get_legend_handles_labels()[1] == ["series-1.en KDE"]
     assert len(plot.ax.collections) == 1
+    assert plot.ax.lines[0].get_color() == series_color(1, "Light")
 
 
 def test_histogram_statistics_draw_single_mean_and_median_lines():
@@ -299,6 +301,7 @@ def test_time_main_data_skips_files_missing_selected_parameter():
         "series-1.en (4 unit)"
     ]
     assert len(plot.ax.lines) == 1
+    assert plot.ax.lines[0].get_color() == series_color(1, "Light")
 
 
 def test_running_average_rejects_invalid_window_size_without_crashing(caplog):
@@ -472,6 +475,30 @@ def test_dashboard_uses_compact_latest_titles_for_multiple_files():
     plot.redraw()
 
     assert plot.axes[0].get_title(loc="right") == "302 | 304 K"
+
+
+def test_dashboard_keeps_file_colors_when_a_parameter_is_missing():
+    first = FakeDashboardEnergy()
+    first.info.pop("TEMPERATURE")
+    first.units.pop("TEMPERATURE")
+    first.data.pop("TEMPERATURE")
+    second = FakeDashboardEnergy()
+    app = FakeApp([first, second])
+    plot = PlotDashboard(app)
+
+    plot.redraw()
+
+    assert [line.get_color() for line in plot.axes[0].lines] == [
+        series_color(1, "Light")
+    ]
+    assert [line.get_color() for line in plot.axes[1].lines] == [
+        series_color(0, "Light"),
+        series_color(1, "Light"),
+    ]
+    assert [text.get_text() for text in plot.figure.legends[0].get_texts()] == [
+        "series-0.en",
+        "series-1.en",
+    ]
 
 
 def test_dashboard_multi_value_title_keeps_mixed_units():

--- a/tests/plots/test_terminal_chart.py
+++ b/tests/plots/test_terminal_chart.py
@@ -15,6 +15,15 @@ class FakeEnergy:
         self.simulation_time = np.array(time)
 
 
+class FakeMissingParameterEnergy:
+
+    def __init__(self):
+        self.info = {"OTHER": "OTHER"}
+        self.units = {"OTHER": "other-unit"}
+        self.data = {"OTHER": np.array([10.0, 11.0, 12.0])}
+        self.simulation_time = np.array([1, 2, 3])
+
+
 class FakeReader:
 
     def __init__(self, energies):
@@ -31,6 +40,19 @@ def test_terminal_chart_contains_labels_and_series_name():
     assert "PARAMETER / unit" in chart
     assert "Simulation Time" in chart
     assert "run-0.en" in chart
+
+
+def test_terminal_chart_skips_files_missing_selected_parameter():
+    reader = FakeReader([
+        FakeMissingParameterEnergy(),
+        FakeEnergy([1.0, 2.0, 5.0]),
+    ])
+
+    chart = build_terminal_chart(reader, "PARAMETER", width=48, height=12)
+
+    assert "PARAMETER / unit" in chart
+    assert "run-0.en" not in chart
+    assert "run-1.en" in chart
 
 
 def test_terminal_chart_can_render_statistic_overlays():

--- a/tests/plots/test_terminal_chart.py
+++ b/tests/plots/test_terminal_chart.py
@@ -1,7 +1,9 @@
 import numpy as np
 
+from PQEnalyzer.plots import terminal_chart
 from PQEnalyzer.plots.terminal_chart import build_terminal_chart
 from PQEnalyzer.plots.options import PlotOptions
+from PQEnalyzer.plots.theme import series_rgb
 
 
 class FakeEnergy:
@@ -42,17 +44,26 @@ def test_terminal_chart_contains_labels_and_series_name():
     assert "run-0.en" in chart
 
 
-def test_terminal_chart_skips_files_missing_selected_parameter():
+def test_terminal_chart_skips_files_without_shifting_file_color(monkeypatch):
     reader = FakeReader([
         FakeMissingParameterEnergy(),
         FakeEnergy([1.0, 2.0, 5.0]),
     ])
+    colors = {}
+    original_plot = terminal_chart.plt.plot
+
+    def recording_plot(*args, **kwargs):
+        colors[kwargs["label"]] = kwargs["color"]
+        return original_plot(*args, **kwargs)
+
+    monkeypatch.setattr(terminal_chart.plt, "plot", recording_plot)
 
     chart = build_terminal_chart(reader, "PARAMETER", width=48, height=12)
 
     assert "PARAMETER / unit" in chart
     assert "run-0.en" not in chart
     assert "run-1.en" in chart
+    assert colors["run-1.en"] == series_rgb(1, "Dark")
 
 
 def test_terminal_chart_can_render_statistic_overlays():

--- a/tests/plots/test_theme.py
+++ b/tests/plots/test_theme.py
@@ -31,6 +31,12 @@ def test_apply_matplotlib_theme_sets_dark_defaults():
             "legend"]
 
 
+def test_series_colors_are_stable_by_file_index():
+    assert theme.series_color(1, "Light") == theme.LIGHT_PALETTE["colors"][1]
+    assert theme.series_color(9, "Light") == theme.LIGHT_PALETTE["colors"][1]
+    assert theme.series_rgb(1, "Dark") == (251, 113, 133)
+
+
 def test_apply_figure_theme_updates_existing_plot_elements():
     with mpl.rc_context():
         figure, axes = plt.subplots()

--- a/tests/reader/test_reader.py
+++ b/tests/reader/test_reader.py
@@ -47,11 +47,15 @@ class TestReader:
         assert len(energy.info) == 12
 
     @pytest.mark.parametrize("example_dir", ["tests/data/"], indirect=False)
-    def test_multiple_input_with_error(self, example_dir):
+    def test_multiple_input_with_missing_parameters(self, example_dir):
         list_filenames = [example_dir + "md-01.en", example_dir + "md-02.en"]
 
-        with pytest.raises(ValueError):
-            Reader(list_filenames, MDEngineFormat.PQ)
+        energy_files = Reader(list_filenames, MDEngineFormat.PQ).energies
+
+        assert "VOLUME" not in energy_files[0].info
+        assert "DENSITY" not in energy_files[0].info
+        assert "VOLUME" in energy_files[1].info
+        assert "DENSITY" in energy_files[1].info
 
     @pytest.mark.parametrize("example_dir", ["tests/data/"], indirect=False)
     def test_multiple_input_with_different_parameters(self, tmp_path,
@@ -67,14 +71,16 @@ class TestReader:
             "VOLUME", "BOX-VOLUME", 1))
         changed.with_suffix(".info").write_text(changed_info)
 
-        with pytest.raises(ValueError, match="same info parameters"):
-            Reader(
-                [
-                    str(reference.with_suffix(".en")),
-                    str(changed.with_suffix(".en")),
-                ],
-                MDEngineFormat.PQ,
-            )
+        energy_files = Reader(
+            [
+                str(reference.with_suffix(".en")),
+                str(changed.with_suffix(".en")),
+            ],
+            MDEngineFormat.PQ,
+        ).energies
+
+        assert "VOLUME" in energy_files[0].info
+        assert "BOX-VOLUME" in energy_files[1].info
 
     @pytest.mark.parametrize("example_dir", ["tests/data/"], indirect=False)
     def test_multiple_input_with_different_units(self, tmp_path, example_dir):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,16 +37,16 @@ def test_cli_help_mentions_gui_and_tui_modes():
     assert "tui" in result.stdout
 
 
-def test_default_gui_mode_logs_reader_validation_errors():
+def test_default_gui_mode_logs_reader_errors():
     project_root = Path(__file__).resolve().parents[1]
+    missing_file = "tests/data/does-not-exist.en"
 
     result = subprocess.run(
         [
             sys.executable,
             "-m",
             "PQEnalyzer",
-            "tests/data/md-01.en",
-            "tests/data/md-02.en",
+            missing_file,
         ],
         cwd=project_root,
         capture_output=True,
@@ -56,12 +56,12 @@ def test_default_gui_mode_logs_reader_validation_errors():
 
     assert result.returncode == 1
     assert "Traceback" not in result.stderr
-    assert "ERROR: The energy files do not have the same info parameters" in (
-        result.stderr)
+    assert f"File {missing_file} not found." in result.stderr
 
 
-def test_explicit_gui_mode_still_logs_reader_validation_errors():
+def test_explicit_gui_mode_still_logs_reader_errors():
     project_root = Path(__file__).resolve().parents[1]
+    missing_file = "tests/data/does-not-exist.en"
 
     result = subprocess.run(
         [
@@ -69,8 +69,7 @@ def test_explicit_gui_mode_still_logs_reader_validation_errors():
             "-m",
             "PQEnalyzer",
             "gui",
-            "tests/data/md-01.en",
-            "tests/data/md-02.en",
+            missing_file,
         ],
         cwd=project_root,
         capture_output=True,
@@ -80,8 +79,7 @@ def test_explicit_gui_mode_still_logs_reader_validation_errors():
 
     assert result.returncode == 1
     assert "Traceback" not in result.stderr
-    assert "ERROR: The energy files do not have the same info parameters" in (
-        result.stderr)
+    assert f"File {missing_file} not found." in result.stderr
 
 
 def test_tui_mode_does_not_duplicate_upstream_reader_errors():
@@ -133,14 +131,14 @@ def test_cli_rejects_multiple_forced_input_formats():
 
 def test_cli_defaults_to_gui_mode():
     project_root = Path(__file__).resolve().parents[1]
+    missing_file = "tests/data/does-not-exist.en"
 
     result = subprocess.run(
         [
             sys.executable,
             "-m",
             "PQEnalyzer",
-            "tests/data/md-01.en",
-            "tests/data/md-02.en",
+            missing_file,
         ],
         cwd=project_root,
         capture_output=True,
@@ -151,8 +149,7 @@ def test_cli_defaults_to_gui_mode():
     assert result.returncode == 1
     assert "Traceback" not in result.stderr
     assert "invalid choice" not in result.stderr
-    assert "ERROR: The energy files do not have the same info parameters" in (
-        result.stderr)
+    assert f"File {missing_file} not found." in result.stderr
 
 
 def test_default_gui_mode_accepts_input_format_flags():

--- a/tests/test_energy_access.py
+++ b/tests/test_energy_access.py
@@ -5,11 +5,15 @@ from PQAnalysis.io import EnergyFileReader
 from PQAnalysis.traj import MDEngineFormat
 
 from PQEnalyzer.energy_access import (
+    available_parameters,
     concatenate_parameter,
     concatenate_series,
     concatenate_time,
     difference_series,
+    energies_with_parameter,
+    has_parameter,
     parameter_unit,
+    parameter_unit_for_energies,
     parameter_values,
     series,
     simulation_time,
@@ -80,6 +84,49 @@ def test_concatenate_helpers_join_series_from_multiple_energy_files():
     assert energy_series.unit == "ps"
 
 
+def test_energy_access_omits_files_missing_selected_parameter():
+    energies = Reader(
+        ["tests/data/md-01.en", "tests/data/md-02.en"],
+        MDEngineFormat.PQ,
+    ).energies
+
+    assert has_parameter(energies[0], "VOLUME") is False
+    assert has_parameter(energies[1], "VOLUME") is True
+    assert energies_with_parameter(energies, "VOLUME") == [energies[1]]
+    assert "VOLUME" in available_parameters(energies, include_time=False)
+    assert "DENSITY" in available_parameters(energies, include_time=False)
+    assert parameter_unit_for_energies(energies, "VOLUME") == "A^3"
+
+    energy_series = concatenate_series(energies, "VOLUME")
+
+    np.testing.assert_array_equal(energy_series.time, np.arange(6, 11))
+    np.testing.assert_allclose(energy_series.values, energies[1].volume)
+    assert energy_series.unit == "A^3"
+
+
+def test_parameter_access_rejects_missing_parameter():
+    energy = read_energy("tests/data/md-01.en")
+
+    with pytest.raises(ValueError, match="not present"):
+        parameter_values(energy, "VOLUME")
+
+    with pytest.raises(ValueError, match="not present"):
+        parameter_unit(energy, "VOLUME")
+
+
+def test_collection_parameter_access_rejects_missing_parameter():
+    energies = [CustomEnergy()]
+
+    with pytest.raises(ValueError, match="not present in any input file"):
+        parameter_unit_for_energies(energies, "MISSING")
+
+    with pytest.raises(ValueError, match="not present in any input file"):
+        concatenate_parameter(energies, "MISSING")
+
+    with pytest.raises(ValueError, match="not present in any input file"):
+        concatenate_series(energies, "MISSING")
+
+
 def test_difference_series_subtracts_two_aligned_series():
     first = CustomEnergy(values=[10.0, 11.0, 12.0])
     second = CustomEnergy(values=[1.0, 2.0, 3.0])
@@ -97,6 +144,16 @@ def test_difference_series_requires_exactly_two_files():
 
     with pytest.raises(ValueError, match="exactly two input files"):
         difference_series([energy], "CUSTOM")
+
+
+def test_difference_series_requires_parameter_in_both_files():
+    energies = Reader(
+        ["tests/data/md-01.en", "tests/data/md-02.en"],
+        MDEngineFormat.PQ,
+    ).energies
+
+    with pytest.raises(ValueError, match="selected parameter in both"):
+        difference_series(energies, "VOLUME")
 
 
 def test_difference_series_uses_shared_time_axis_values():


### PR DESCRIPTION
## Summary
- allow multi-file energy reads when files expose different parameter sets
- make GUI, TUI, dashboard, time plots, histograms, and terminal charts skip files that lack the selected parameter
- keep unit validation for shared parameters and keep difference plotting strict when a selected parameter is missing from either file
- update README and regression tests for the issue #82 fixture

Fixes #82.

## Validation
- python -m pytest -m "not benchmark"
- manual Reader check: `md-01 + md-02` now exposes `VOLUME`/`DENSITY`, `VOLUME` has 5 rows from the second file, and `TEMPERATURE` keeps 10 rows across both files