### PR TITLE
Repair Live Monitor layout and plot sizing

### DIFF
--- a/PQEnalyzer/apps/app.py
+++ b/PQEnalyzer/apps/app.py
@@ -2,6 +2,7 @@
 Graphical CustomTkinter application coordinator.
 """
 
+import math
 import signal
 
 import customtkinter as ctk
@@ -9,6 +10,14 @@ import matplotlib.pyplot as plt
 
 from .._logging import get_logger
 from ..energy_access import available_parameters
+from ..preferences import (
+    PLOT_SIZE_KEYS,
+    adjusted_plot_scale,
+    load_preferences,
+    plot_scale_from_label,
+    plot_scale_label,
+    save_preferences,
+)
 from ..plots import PlotDashboard, PlotTime, PlotHistogram
 from ..plots.features import PLOT_FEATURES
 from ..plots.options import PlotOptions
@@ -50,10 +59,14 @@ class App(ctk.CTk):
         """
         Initialize the root window and derive selectable parameters.
         """
+        self.preferences = load_preferences()
+        self.appearance_mode_setting = self.preferences.appearance_mode
+        self.plot_scale = self.preferences.plot_scale
+        configure_default_theme(self.appearance_mode_setting)
         super().__init__()
-        configure_default_theme()
-        self.appearance_mode = resolve_appearance_mode("System")
-        apply_matplotlib_theme(self.appearance_mode)
+        self.appearance_mode = resolve_appearance_mode(
+            self.appearance_mode_setting)
+        apply_matplotlib_theme(self.appearance_mode, self.plot_scale)
         configure_window(self)
 
         self.reader = reader
@@ -65,8 +78,10 @@ class App(ctk.CTk):
         self.list_of_plots = []
         self.selected_plot = None
         self.__syncing_plot_controls = False
+        self.__restoring_preferences = False
         self.__file_watcher = None
         self.__auto_refresh_after_id = None
+        self.__preferences_after_id = None
 
         signal.signal(signal.SIGINT,
                       lambda sig, frame: self.destroy())
@@ -75,6 +90,14 @@ class App(ctk.CTk):
         """
         Destroy the app.
         """
+        if "preferences" in self.__dict__:
+            preferences_after_id = self.__dict__.get(
+                "_App__preferences_after_id")
+            if preferences_after_id is not None:
+                self.after_cancel(preferences_after_id)
+                self.__preferences_after_id = None
+            self.__write_preferences()
+
         self.__stop_file_watcher()
         plt.close("all")
         self.quit()
@@ -84,8 +107,13 @@ class App(ctk.CTk):
         """
         Create all view objects and attach their widgets to the root window.
         """
+        if "preferences" in self.__dict__:
+            self.__restoring_preferences = True
         self.sidebar_view = SidebarView(
-            self, self.__change_appearance_mode_event)
+            self,
+            self.__change_appearance_mode_event,
+            self.change_plot_scale,
+        )
         self.plot_controls_view = PlotControlsView(
             self,
             self.__plot_button_event,
@@ -96,6 +124,8 @@ class App(ctk.CTk):
             self, self.__change_info_event)
         self.statistics_controls_view = StatisticsControlsView(
             self, self.__statistics_control_event)
+        if "preferences" in self.__dict__:
+            self.__restore_preferences()
         if "auto_refresh" in self.__dict__:
             self.__auto_refresh_control_event()
 
@@ -141,15 +171,76 @@ class App(ctk.CTk):
 
         return parsed_value
 
+    def change_plot_scale(self, selection):
+        """
+        Apply and persist a plot typography preset.
+        """
+
+        if selection in {"increase", "decrease", "reset"}:
+            plot_scale = adjusted_plot_scale(self.plot_scale, selection)
+        else:
+            plot_scale = plot_scale_from_label(selection)
+
+        if plot_scale == self.plot_scale:
+            return None
+
+        self.plot_scale = plot_scale
+        apply_matplotlib_theme(self.appearance_mode, plot_scale)
+
+        scale_option = self.__dict__.get("plot_scale_optionemenu")
+        if scale_option is not None:
+            scale_option.set(plot_scale_label(plot_scale))
+
+        self.__redraw_plots()
+        self.__schedule_preferences_save()
+        return None
+
+    def plot_size(self, plot_kind, default):
+        """
+        Return the last window size for one plot kind.
+        """
+
+        return self.preferences.plot_sizes.get(plot_kind, default)
+
+    def remember_plot_size(self, plot_kind, size):
+        """
+        Store a resized Matplotlib window for the next launch.
+        """
+
+        if plot_kind not in PLOT_SIZE_KEYS:
+            raise ValueError(f"Unknown plot kind: {plot_kind}")
+
+        width, height = (float(dimension) for dimension in size)
+        if (
+            not math.isfinite(width)
+            or not math.isfinite(height)
+            or width <= 0
+            or height <= 0
+        ):
+            return None
+
+        remembered_size = round(width, 2), round(height, 2)
+        if self.preferences.plot_sizes.get(plot_kind) == remembered_size:
+            return None
+
+        self.preferences.plot_sizes[plot_kind] = remembered_size
+        self.__schedule_preferences_save()
+        return None
+
     def __change_appearance_mode_event(self, new_appearance_mode: str):
         """
         Apply a CustomTkinter appearance-mode selection.
         """
 
+        self.appearance_mode_setting = new_appearance_mode
         ctk.set_appearance_mode(new_appearance_mode)
         self.appearance_mode = resolve_appearance_mode(new_appearance_mode)
-        apply_matplotlib_theme(self.appearance_mode)
+        apply_matplotlib_theme(
+            self.appearance_mode,
+            self.__dict__.get("plot_scale", 1.0),
+        )
         self.__redraw_plots()
+        self.__schedule_preferences_save()
 
     def __change_info_event(self, new_info: str):
         """
@@ -157,6 +248,7 @@ class App(ctk.CTk):
         """
 
         self.__selected_info = new_info
+        self.__schedule_preferences_save()
 
     def __refresh_plots(self, show=True):
         """
@@ -219,6 +311,7 @@ class App(ctk.CTk):
             self.__stop_file_watcher()
             self.__set_auto_refresh_status("Auto-refresh paused")
 
+        self.__schedule_preferences_save()
         return None
 
     def __start_file_watcher(self):
@@ -337,6 +430,7 @@ class App(ctk.CTk):
             return
 
         self.__sync_plot_controls(plot.options)
+        self.__schedule_preferences_save()
 
     def __statistics_control_event(self):
         """
@@ -346,6 +440,7 @@ class App(ctk.CTk):
         if self.__syncing_plot_controls:
             return None
 
+        self.__schedule_preferences_save()
         if self.selected_plot is None:
             return None
 
@@ -401,3 +496,82 @@ class App(ctk.CTk):
         entry.delete(0, ctk.END)
         if value:
             entry.insert(0, value)
+
+    def __restore_preferences(self):
+        """
+        Restore the last controls that are valid for the loaded files.
+        """
+
+        self.__restoring_preferences = True
+        try:
+            self.__set_checkbox(
+                self.auto_refresh,
+                self.preferences.auto_refresh,
+            )
+            self.__sync_plot_controls(
+                PlotOptions.from_mapping(self.preferences.plot_options))
+
+            selected_parameter = self.preferences.selected_parameter
+            if selected_parameter in self.info:
+                self.info_optionmenu.set(selected_parameter)
+                self.__selected_info = selected_parameter
+
+            self.plot_scale_optionemenu.set(
+                plot_scale_label(self.plot_scale))
+            self.appearance_mode_optionemenu.set(
+                self.appearance_mode_setting)
+        finally:
+            self.__restoring_preferences = False
+
+    def __schedule_preferences_save(self):
+        """
+        Debounce preference writes after GUI and plot changes.
+        """
+
+        if (
+            "preferences" not in self.__dict__
+            or getattr(self, "_App__restoring_preferences", False)
+        ):
+            return None
+
+        preferences_after_id = self.__dict__.get(
+            "_App__preferences_after_id")
+        if preferences_after_id is not None:
+            self.after_cancel(preferences_after_id)
+
+        self.__preferences_after_id = self.after(
+            300,
+            self.__write_preferences,
+        )
+        return None
+
+    def __capture_preferences(self):
+        """
+        Copy the current widgets into the persistent preference object.
+        """
+
+        self.preferences.appearance_mode = self.appearance_mode_setting
+        self.preferences.plot_scale = self.plot_scale
+        self.preferences.selected_parameter = self.__dict__.get(
+            "_App__selected_info")
+
+        if "auto_refresh" in self.__dict__:
+            self.preferences.auto_refresh = bool(self.auto_refresh.get())
+
+        required_options = [
+            "plot_main_data",
+            "window_size",
+            *(feature.option_attribute for feature in PLOT_FEATURES),
+        ]
+        if all(option in self.__dict__ for option in required_options):
+            self.preferences.plot_options = (
+                PlotOptions.from_app(self).to_mapping())
+
+    def __write_preferences(self):
+        """
+        Persist the latest user settings immediately.
+        """
+
+        self.__preferences_after_id = None
+        self.__capture_preferences()
+        return save_preferences(self.preferences)

--- a/PQEnalyzer/apps/app_layout.py
+++ b/PQEnalyzer/apps/app_layout.py
@@ -13,16 +13,19 @@ from pathlib import Path
 import customtkinter as ctk
 from PIL import Image, ImageTk
 
-ICON_PATH = Path(__file__).resolve().parents[1] / "icons" / "icon.png"
+from ..preferences import PLOT_SCALE_LABELS, plot_scale_label
 from ..plots.features import STATISTIC_FEATURES, TIME_SERIES_FEATURES
 
 
-def configure_default_theme():
+ICON_PATH = Path(__file__).resolve().parents[1] / "icons" / "icon.png"
+
+
+def configure_default_theme(appearance_mode="System"):
     """
-    Configure the default CustomTkinter theme.
+    Configure the persisted CustomTkinter theme.
     """
 
-    ctk.set_appearance_mode("System")
+    ctk.set_appearance_mode(appearance_mode)
     ctk.set_default_color_theme("blue")
 
 
@@ -54,9 +57,15 @@ class SidebarView:
         Callback invoked by the appearance-mode option menu.
     """
 
-    def __init__(self, app, change_appearance_mode_callback):
+    def __init__(
+        self,
+        app,
+        change_appearance_mode_callback,
+        change_plot_scale_callback,
+    ):
         self.app = app
         self.change_appearance_mode_callback = change_appearance_mode_callback
+        self.change_plot_scale_callback = change_plot_scale_callback
 
         self.frame = ctk.CTkFrame(app, width=140, corner_radius=0)
         self.frame.grid(row=0, column=0, rowspan=4, sticky="nsew")
@@ -78,12 +87,37 @@ class SidebarView:
         )
         self.logo_label.grid(row=1, column=0, padx=10, pady=10)
 
+        self.plot_scale_label = ctk.CTkLabel(
+            self.frame,
+            text="Plot Size:",
+            anchor="w",
+        )
+        self.plot_scale_label.grid(
+            row=5,
+            column=0,
+            padx=20,
+            pady=(10, 0),
+        )
+        self.plot_scale_optionemenu = ctk.CTkOptionMenu(
+            self.frame,
+            values=list(PLOT_SCALE_LABELS),
+            command=change_plot_scale_callback,
+        )
+        self.plot_scale_optionemenu.grid(
+            row=6,
+            column=0,
+            padx=20,
+            pady=(10, 10),
+        )
+        self.plot_scale_optionemenu.set(
+            plot_scale_label(getattr(app, "plot_scale", 1.0)))
+
         self.appearance_mode_label = ctk.CTkLabel(
             self.frame,
             text="Appearance Mode:",
             anchor="w",
         )
-        self.appearance_mode_label.grid(row=5,
+        self.appearance_mode_label.grid(row=7,
                                         column=0,
                                         padx=20,
                                         pady=(10, 0))
@@ -92,16 +126,18 @@ class SidebarView:
             values=["System", "Light", "Dark"],
             command=change_appearance_mode_callback,
         )
-        self.appearance_mode_optionemenu.grid(row=6,
+        self.appearance_mode_optionemenu.grid(row=8,
                                               column=0,
                                               padx=20,
                                               pady=(10, 10))
-        self.appearance_mode_optionemenu.set("System")
+        self.appearance_mode_optionemenu.set(
+            getattr(app, "appearance_mode_setting", "System"))
 
         app.sidebar_frame = self.frame
         app.logo = self.logo
         app.sidebar_image_label = self.image_label
         app.logo_label = self.logo_label
+        app.plot_scale_optionemenu = self.plot_scale_optionemenu
         app.appearance_mode_label = self.appearance_mode_label
         app.appearance_mode_optionemenu = self.appearance_mode_optionemenu
 

--- a/PQEnalyzer/plots/options.py
+++ b/PQEnalyzer/plots/options.py
@@ -2,7 +2,7 @@
 Plot option state shared by GUI plot windows.
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, fields
 
 from .features import PLOT_FEATURES, PLOT_FEATURES_BY_KEY
 
@@ -52,6 +52,37 @@ class PlotOptions:
             )
 
         return options
+
+    @classmethod
+    def from_mapping(cls, values):
+        """
+        Restore known options from persistent settings.
+        """
+
+        if not isinstance(values, dict):
+            return cls()
+
+        options = cls()
+        for option_field in fields(cls):
+            value = values.get(
+                option_field.name,
+                getattr(options, option_field.name),
+            )
+            default = getattr(options, option_field.name)
+            if isinstance(default, bool):
+                if isinstance(value, bool):
+                    setattr(options, option_field.name, value)
+            elif isinstance(value, str):
+                setattr(options, option_field.name, value)
+
+        return options
+
+    def to_mapping(self):
+        """
+        Return JSON-compatible option values.
+        """
+
+        return asdict(self)
 
     @classmethod
     def with_enabled(cls, *feature_keys):

--- a/PQEnalyzer/plots/plot.py
+++ b/PQEnalyzer/plots/plot.py
@@ -8,6 +8,7 @@ import matplotlib.animation as animation
 
 from .._logging import get_logger
 from ..energy_access import parameter_unit_for_energies
+from ..preferences import plot_scale_action
 from .features import PLOT_FEATURES
 from .labels import parameter_label
 from .options import PlotOptions
@@ -64,12 +65,27 @@ class Plot(metaclass=ABCMeta):
 
         # create the plot
         self.palette = apply_matplotlib_theme(
-            getattr(self.app, "appearance_mode", None))
-        self.figure = plt.figure(figsize=SINGLE_PLOT_FIGURE_SIZE)
+            getattr(self.app, "appearance_mode", None),
+            getattr(self.app, "plot_scale", 1.0),
+        )
+        figure_size = (
+            self.app.plot_size("single", SINGLE_PLOT_FIGURE_SIZE)
+            if hasattr(self.app, "plot_size")
+            else SINGLE_PLOT_FIGURE_SIZE
+        )
+        self.figure = plt.figure(figsize=figure_size)
         self.ax = self.figure.add_subplot(111)
         self.apply_theme()
         self.figure.canvas.mpl_connect("button_press_event",
                                        self.__select_plot)
+        self.figure.canvas.mpl_connect(
+            "key_press_event",
+            self.__key_press_event,
+        )
+        self.figure.canvas.mpl_connect(
+            "resize_event",
+            self.__resize_event,
+        )
 
         # set the signal handler
         signal.signal(
@@ -234,6 +250,28 @@ class Plot(metaclass=ABCMeta):
 
         self.app.select_plot(self)
 
+    def __key_press_event(self, event):
+        """
+        Apply plot typography scaling from a focused plot window.
+        """
+
+        action = plot_scale_action(getattr(event, "key", None))
+        if action is not None and hasattr(self.app, "change_plot_scale"):
+            self.app.change_plot_scale(action)
+
+    def __resize_event(self, event):
+        """
+        Refit labels and remember a resized single-plot window.
+        """
+
+        self.figure.tight_layout(pad=2.0)
+        self.figure.canvas.draw_idle()
+        if hasattr(self.app, "remember_plot_size"):
+            self.app.remember_plot_size(
+                "single",
+                self.figure.get_size_inches(),
+            )
+
     def plot_data(self) -> None:
         """
         Render main data, enabled statistics and plot labels.
@@ -318,6 +356,7 @@ class Plot(metaclass=ABCMeta):
             self.figure,
             self.ax,
             getattr(self.app, "appearance_mode", None),
+            getattr(self.app, "plot_scale", 1.0),
         )
 
     @abstractmethod

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -7,6 +7,7 @@ import signal
 
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
+from matplotlib.ticker import MaxNLocator
 import numpy as np
 
 from .._logging import get_logger
@@ -16,11 +17,13 @@ from ..energy_access import (
     parameter_unit_for_energies,
     series,
 )
+from ..preferences import plot_scale_action
 from .labels import parameter_label, unique_path_labels
 from .theme import (
     apply_figure_theme,
     apply_matplotlib_theme,
     palette_for_appearance_mode,
+    scaled_font_size,
     series_color,
 )
 from .value_readout import ValueReadoutEntry, format_readout_value
@@ -47,10 +50,32 @@ class PlotDashboard:
         self.selected_parameter = None
         self.refresh_warning = None
         self.subtitle_text = None
+        self._panel_scale = 1.0
+        self._compact_labels = False
 
-        apply_matplotlib_theme(getattr(self.app, "appearance_mode", None))
-        self.figure = plt.figure(figsize=self.__figure_size())
-        self.axes = self.__create_axes()
+        apply_matplotlib_theme(
+            getattr(self.app, "appearance_mode", None),
+            getattr(self.app, "plot_scale", 1.0),
+        )
+        default_figure_size = self.__figure_size()
+        saved_plot_sizes = getattr(
+            getattr(self.app, "preferences", None),
+            "plot_sizes",
+            {},
+        )
+        self._fit_on_first_open = "dashboard" not in saved_plot_sizes
+        figure_size = (
+            self.app.plot_size("dashboard", default_figure_size)
+            if hasattr(self.app, "plot_size")
+            else default_figure_size
+        )
+        self.figure = plt.figure(figsize=figure_size)
+        self._canvas_size = tuple(
+            dimension * self.figure.dpi
+            for dimension in self.figure.get_size_inches()
+        )
+        self._grid_shape = self.__grid_shape()
+        self.axes = self.__create_axes(self._grid_shape)
         self.ani = None
         self.__set_window_title()
 
@@ -60,6 +85,14 @@ class PlotDashboard:
         )
         self.figure.canvas.mpl_connect("button_press_event",
                                        self.__button_press_event)
+        self.figure.canvas.mpl_connect(
+            "key_press_event",
+            self.__key_press_event,
+        )
+        self.figure.canvas.mpl_connect(
+            "resize_event",
+            self.__resize_event,
+        )
 
     def signal_handler(self, signal, frame):
         """
@@ -75,6 +108,9 @@ class PlotDashboard:
         """
 
         self.redraw()
+        if self._fit_on_first_open:
+            self.fit_to_screen()
+            self._fit_on_first_open = False
         plt.show()
 
     def follow(self, info_parameter=None, interval: float = 1.0) -> None:
@@ -88,6 +124,9 @@ class PlotDashboard:
             return []
 
         self.redraw()
+        if self._fit_on_first_open:
+            self.fit_to_screen()
+            self._fit_on_first_open = False
         self.ani = animation.FuncAnimation(
             self.figure,
             update,
@@ -116,12 +155,17 @@ class PlotDashboard:
         Redraw all raw parameter panels.
         """
 
+        self.__reflow_axes()
+        self._panel_scale = self.__panel_scale()
+        requested_scale = getattr(self.app, "plot_scale", 1.0)
+        self._compact_labels = self._panel_scale < requested_scale - 0.05
         for ax in self.axes:
             ax.clear()
             apply_figure_theme(
                 self.figure,
                 ax,
                 getattr(self.app, "appearance_mode", None),
+                self._panel_scale,
             )
 
         self.axis_parameters = {}
@@ -140,11 +184,11 @@ class PlotDashboard:
         for ax in self.axes[len(self.parameters):]:
             ax.set_visible(False)
 
+        for legend in list(self.figure.legends):
+            legend.remove()
         self.__show_legend(labels)
         self.__set_title()
-        self.figure.tight_layout(rect=(0, 0.03, 1, 0.92),
-                                 h_pad=1.0,
-                                 w_pad=1.2)
+        self.__fit_layout()
         self.figure.canvas.draw_idle()
 
     def __plot_parameter(self, ax, parameter, labels):
@@ -183,9 +227,11 @@ class PlotDashboard:
         unit = parameter_unit_for_energies(self.reader.energies, parameter)
         palette = palette_for_appearance_mode(
             getattr(self.app, "appearance_mode", None))
+        plot_scale = self._panel_scale
+        title_unit = None if self._compact_labels else unit
         ax.set_title(
-            parameter_label(parameter, unit),
-            fontsize=9,
+            parameter_label(parameter, title_unit),
+            fontsize=scaled_font_size(9, plot_scale),
             fontweight="normal",
             loc="left",
             pad=6,
@@ -197,28 +243,47 @@ class PlotDashboard:
             transform=ax.transAxes,
             ha="right",
             va="top",
-            fontsize=7.5,
+            fontsize=scaled_font_size(7.5, plot_scale),
             fontfamily="monospace",
             color=palette["subtle.text"],
             bbox={
-                "boxstyle": "round,pad=0.22",
+                "boxstyle": (
+                    "square,pad=0.12"
+                    if self._compact_labels
+                    else "round,pad=0.22"
+                ),
                 "facecolor": palette["annotation.facecolor"],
                 "edgecolor": "none",
-                "alpha": 0.82,
+                "alpha": 0.72 if self._compact_labels else 0.82,
             },
             clip_on=True,
             zorder=5,
         )
-        ax.ticklabel_format(axis="both", style="sci")
-        ax.tick_params(labelsize=8)
-        ax.xaxis.get_offset_text().set_fontsize(7)
-        ax.yaxis.get_offset_text().set_fontsize(7)
+        ax.ticklabel_format(
+            axis="both",
+            style="sci",
+            scilimits=(-3, 3),
+            useOffset=True,
+        )
+        number_of_ticks = 3 if self._compact_labels else 4
+        ax.xaxis.set_major_locator(
+            MaxNLocator(nbins=number_of_ticks, min_n_ticks=2))
+        ax.yaxis.set_major_locator(
+            MaxNLocator(nbins=number_of_ticks, min_n_ticks=2))
+        ax.tick_params(labelsize=scaled_font_size(8, plot_scale))
+        ax.xaxis.get_offset_text().set_fontsize(
+            scaled_font_size(7, plot_scale))
+        ax.yaxis.get_offset_text().set_fontsize(
+            scaled_font_size(7, plot_scale))
 
-        nrows, ncols = self.__grid_shape()
-        if index // ncols == nrows - 1:
+        nrows, ncols = self._grid_shape
+        bottom_row = index // ncols == nrows - 1
+        ax.tick_params(axis="x", labelbottom=bottom_row)
+        ax.xaxis.get_offset_text().set_visible(bottom_row)
+        if bottom_row:
             ax.set_xlabel(
                 axis_label(self.reader.energies[0]),
-                fontsize=8,
+                fontsize=scaled_font_size(8, plot_scale),
             )
 
     def __add_latest_value(self, parameter, label, line, values):
@@ -246,6 +311,9 @@ class PlotDashboard:
         entries = self.latest_values.get(parameter, [])
         if not entries:
             return ""
+
+        if self._compact_labels and len(entries) > 1:
+            return f"{entries[0].formatted_value} | +{len(entries) - 1}"
 
         if len(entries) == 1:
             return entries[0].formatted_value
@@ -292,7 +360,10 @@ class PlotDashboard:
                 loc="upper right",
                 bbox_to_anchor=(0.995, 0.985),
                 ncol=min(4, len(labels)),
-                fontsize="small",
+                fontsize=scaled_font_size(
+                    9,
+                    self.__header_scale(1.25),
+                ),
                 frameon=True,
             )
             return
@@ -355,26 +426,122 @@ class PlotDashboard:
         if getattr(event, "dblclick", False):
             self.app.open_focus_plot(parameter)
 
-    def __create_axes(self):
+    def __key_press_event(self, event):
+        """
+        Apply plot scaling or fit the dashboard to the screen.
+        """
+
+        key = (getattr(event, "key", None) or "").lower()
+        if key == "f":
+            self.fit_to_screen()
+            return
+
+        action = plot_scale_action(key)
+        if action is not None and hasattr(self.app, "change_plot_scale"):
+            self.app.change_plot_scale(action)
+
+    def fit_to_screen(self):
+        """
+        Fit the native dashboard window to the current display.
+        """
+
+        manager = getattr(self.figure.canvas, "manager", None)
+        window = getattr(manager, "window", None)
+        if window is None:
+            return False
+
+        if hasattr(window, "showMaximized"):
+            window.showMaximized()
+            return True
+
+        if not all(
+            hasattr(window, attribute)
+            for attribute in (
+                "geometry",
+                "winfo_screenwidth",
+                "winfo_screenheight",
+            )
+        ):
+            return False
+
+        screen_width = int(window.winfo_screenwidth())
+        screen_height = int(window.winfo_screenheight())
+        horizontal_margin = max(20, round(screen_width * 0.025))
+        vertical_margin = max(40, round(screen_height * 0.05))
+        width = screen_width - 2 * horizontal_margin
+        height = screen_height - 2 * vertical_margin
+        window.geometry(
+            f"{width}x{height}+{horizontal_margin}+{vertical_margin}"
+        )
+        return True
+
+    def __resize_event(self, event):
+        """
+        Reflow the grid and remember the resized dashboard window.
+        """
+
+        width = getattr(event, "width", None)
+        height = getattr(event, "height", None)
+        grid_changed = self.__reflow_axes(width, height)
+        panel_scale = self.__panel_scale()
+        requested_scale = getattr(self.app, "plot_scale", 1.0)
+        compact_labels = panel_scale < requested_scale - 0.05
+        style_changed = (
+            panel_scale != self._panel_scale
+            or compact_labels != self._compact_labels
+        )
+        if grid_changed or style_changed:
+            self.redraw()
+        else:
+            self.__fit_layout()
+            self.figure.canvas.draw_idle()
+
+        if hasattr(self.app, "remember_plot_size"):
+            self.app.remember_plot_size(
+                "dashboard",
+                self.figure.get_size_inches(),
+            )
+
+    def __create_axes(self, grid_shape):
         """
         Create enough axes for all dashboard parameters.
         """
 
-        nrows, ncols = self.__grid_shape()
+        nrows, ncols = grid_shape
         axes = self.figure.subplots(nrows=nrows, ncols=ncols, squeeze=False)
         return list(axes.flat)
 
-    def __grid_shape(self):
+    def __grid_shape(self, width=None, height=None):
         """
-        Return a compact dashboard grid that remains screen-shaped.
+        Return a responsive grid for the current window shape.
         """
 
+        if width is None or height is None:
+            figure = getattr(self, "figure", None)
+            if figure is None:
+                width, height = 15.0, 9.5
+            else:
+                width, height = figure.get_size_inches()
+
+        width = max(float(width), 1.0)
+        height = max(float(height), 1.0)
         number_of_parameters = max(1, len(self.parameters))
-        ncols = min(
-            5,
-            max(1, round(math.sqrt(number_of_parameters * 4 / 3))),
-        )
-        nrows = math.ceil(number_of_parameters / ncols)
+        target_panel_aspect = 1.45
+
+        candidates = []
+        for ncols in range(1, min(6, number_of_parameters) + 1):
+            nrows = math.ceil(number_of_parameters / ncols)
+            panel_aspect = (width / ncols) / (height / nrows)
+            aspect_error = abs(
+                math.log(panel_aspect / target_panel_aspect)
+            )
+            empty_ratio = (
+                nrows * ncols - number_of_parameters
+            ) / number_of_parameters
+            score = aspect_error + 0.8 * empty_ratio
+            candidates.append((score, nrows * ncols, nrows, ncols))
+
+        _, _, nrows, ncols = min(candidates)
         return nrows, ncols
 
     def __figure_size(self):
@@ -382,10 +549,86 @@ class PlotDashboard:
         Return a readable figure size for the current parameter count.
         """
 
-        nrows, ncols = self.__grid_shape()
+        nrows, ncols = self.__grid_shape(15.0, 9.5)
         width = min(15.0, max(8.5, 3.1 * ncols))
         height = min(9.5, max(4.8, 2.2 * nrows + 1.2))
         return width, height
+
+    def __panel_scale(self):
+        """
+        Cap dense panel typography by the available canvas area.
+        """
+
+        requested_scale = float(getattr(self.app, "plot_scale", 1.0))
+        if requested_scale <= 1.0:
+            return requested_scale
+
+        width, height = self._canvas_size
+        nrows, ncols = self._grid_shape
+        panel_width = width / ncols
+        panel_height = height * 0.82 / nrows
+        width_capacity = max(1.0, panel_width / 260)
+        height_capacity = max(1.0, panel_height / 170)
+        panel_scale = min(
+            requested_scale,
+            width_capacity,
+            height_capacity,
+            1.5,
+        )
+        return math.floor(panel_scale * 20 + 1e-9) / 20
+
+    def __header_scale(self, maximum):
+        """
+        Return a bounded scale for shared dashboard header elements.
+        """
+
+        return min(float(getattr(self.app, "plot_scale", 1.0)), maximum)
+
+    def __reflow_axes(self, width=None, height=None):
+        """
+        Recreate dashboard axes when the responsive grid shape changes.
+        """
+
+        if width is None or height is None:
+            width, height = (
+                dimension * self.figure.dpi
+                for dimension in self.figure.get_size_inches()
+            )
+        width = max(float(width), 1.0)
+        height = max(float(height), 1.0)
+        grid_shape = self.__grid_shape(width, height)
+        previous_width, previous_height = self._canvas_size
+        previous_slots = self._grid_shape[0] * self._grid_shape[1]
+        candidate_slots = grid_shape[0] * grid_shape[1]
+        previous_panel_area = (
+            previous_width * previous_height / previous_slots
+        )
+        candidate_panel_area = width * height / candidate_slots
+        window_grew = width * height >= previous_width * previous_height
+        if window_grew and candidate_panel_area < previous_panel_area:
+            grid_shape = self._grid_shape
+
+        self._canvas_size = width, height
+        if grid_shape == self._grid_shape:
+            return False
+
+        self.figure.clear()
+        self.subtitle_text = None
+        self.axis_parameters = {}
+        self._grid_shape = grid_shape
+        self.axes = self.__create_axes(grid_shape)
+        return True
+
+    def __fit_layout(self):
+        """
+        Refit dashboard labels to the current canvas dimensions.
+        """
+
+        self.figure.tight_layout(
+            rect=(0, 0.03, 1, 0.92),
+            h_pad=0.7,
+            w_pad=0.8,
+        )
 
     def __style_axis(self, ax, parameter):
         """
@@ -434,7 +677,10 @@ class PlotDashboard:
             y=0.985,
             ha="left",
             va="top",
-            fontsize=14,
+            fontsize=scaled_font_size(
+                14,
+                self.__header_scale(1.5),
+            ),
             fontweight="bold",
             color=palette["text.color"],
         )
@@ -445,12 +691,20 @@ class PlotDashboard:
                 subtitle,
                 ha="left",
                 va="top",
-                fontsize=9,
+                fontsize=scaled_font_size(
+                    9,
+                    self.__header_scale(1.25),
+                ),
                 color=color,
             )
         else:
             self.subtitle_text.set_text(subtitle)
             self.subtitle_text.set_color(color)
+            self.subtitle_text.set_fontsize(
+                scaled_font_size(
+                    9,
+                    self.__header_scale(1.25),
+                ))
 
     def __set_window_title(self):
         """

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -186,18 +186,33 @@ class PlotDashboard:
         ax.set_title(
             parameter_label(parameter, unit),
             fontsize=9,
+            fontweight="normal",
             loc="left",
             pad=6,
         )
-        ax.set_title(
+        ax.text(
+            0.985,
+            0.965,
             self.__latest_value_title(parameter),
-            fontsize=8,
-            loc="right",
-            pad=6,
+            transform=ax.transAxes,
+            ha="right",
+            va="top",
+            fontsize=7.5,
+            fontfamily="monospace",
             color=palette["subtle.text"],
+            bbox={
+                "boxstyle": "round,pad=0.22",
+                "facecolor": palette["annotation.facecolor"],
+                "edgecolor": "none",
+                "alpha": 0.82,
+            },
+            clip_on=True,
+            zorder=5,
         )
         ax.ticklabel_format(axis="both", style="sci")
         ax.tick_params(labelsize=8)
+        ax.xaxis.get_offset_text().set_fontsize(7)
+        ax.yaxis.get_offset_text().set_fontsize(7)
 
         nrows, ncols = self.__grid_shape()
         if index // ncols == nrows - 1:
@@ -208,7 +223,7 @@ class PlotDashboard:
 
     def __add_latest_value(self, parameter, label, line, values):
         """
-        Store one dashboard line's latest value for the axis title.
+        Store one dashboard line's latest value for its panel readout.
         """
 
         if len(values) == 0:
@@ -225,7 +240,7 @@ class PlotDashboard:
 
     def __latest_value_title(self, parameter):
         """
-        Return the compact latest-value text for a dashboard axis.
+        Return the compact latest-value text for a dashboard panel.
         """
 
         entries = self.latest_values.get(parameter, [])
@@ -351,11 +366,14 @@ class PlotDashboard:
 
     def __grid_shape(self):
         """
-        Return a compact dashboard grid shape.
+        Return a compact dashboard grid that remains screen-shaped.
         """
 
         number_of_parameters = max(1, len(self.parameters))
-        ncols = min(3, math.ceil(math.sqrt(number_of_parameters)))
+        ncols = min(
+            5,
+            max(1, round(math.sqrt(number_of_parameters * 4 / 3))),
+        )
         nrows = math.ceil(number_of_parameters / ncols)
         return nrows, ncols
 
@@ -365,18 +383,17 @@ class PlotDashboard:
         """
 
         nrows, ncols = self.__grid_shape()
-        return (4.4 * ncols, 2.8 * nrows)
+        width = min(15.0, max(8.5, 3.1 * ncols))
+        height = min(9.5, max(4.8, 2.2 * nrows + 1.2))
+        return width, height
 
     def __style_axis(self, ax, parameter):
         """
         Apply dashboard panel styling and selected-panel emphasis.
         """
 
-        palette = apply_figure_theme(
-            self.figure,
-            ax,
-            getattr(self.app, "appearance_mode", None),
-        )
+        palette = palette_for_appearance_mode(
+            getattr(self.app, "appearance_mode", None))
         selected = parameter == self.selected_parameter
         edgecolor = (
             palette["selected.edgecolor"]

--- a/PQEnalyzer/plots/plot_dashboard.py
+++ b/PQEnalyzer/plots/plot_dashboard.py
@@ -30,6 +30,7 @@ from .value_readout import ValueReadoutEntry, format_readout_value
 
 
 logger = get_logger(__name__)
+RESIZE_DEBOUNCE_MS = 120
 
 
 class PlotDashboard:
@@ -52,6 +53,8 @@ class PlotDashboard:
         self.subtitle_text = None
         self._panel_scale = 1.0
         self._compact_labels = False
+        self._pending_resize = None
+        self._resize_after_id = None
 
         apply_matplotlib_theme(
             getattr(self.app, "appearance_mode", None),
@@ -477,11 +480,46 @@ class PlotDashboard:
 
     def __resize_event(self, event):
         """
-        Reflow the grid and remember the resized dashboard window.
+        Remember the window size and coalesce expensive dashboard relayouts.
         """
 
         width = getattr(event, "width", None)
         height = getattr(event, "height", None)
+        self._pending_resize = width, height
+
+        if hasattr(self.app, "remember_plot_size"):
+            self.app.remember_plot_size(
+                "dashboard",
+                self.figure.get_size_inches(),
+            )
+
+        schedule = getattr(self.app, "after", None)
+        cancel = getattr(self.app, "after_cancel", None)
+        if not callable(schedule) or not callable(cancel):
+            self.__apply_pending_resize()
+            return
+
+        if self._resize_after_id is not None:
+            cancel(self._resize_after_id)
+        self._resize_after_id = schedule(
+            RESIZE_DEBOUNCE_MS,
+            self.__apply_pending_resize,
+        )
+
+    def __apply_pending_resize(self):
+        """
+        Apply the final layout after a burst of native resize events.
+        """
+
+        self._resize_after_id = None
+        if self._pending_resize is None:
+            return
+
+        width, height = self._pending_resize
+        self._pending_resize = None
+        if self.figure.number not in plt.get_fignums():
+            return
+
         grid_changed = self.__reflow_axes(width, height)
         panel_scale = self.__panel_scale()
         requested_scale = getattr(self.app, "plot_scale", 1.0)
@@ -495,12 +533,6 @@ class PlotDashboard:
         else:
             self.__fit_layout()
             self.figure.canvas.draw_idle()
-
-        if hasattr(self.app, "remember_plot_size"):
-            self.app.remember_plot_size(
-                "dashboard",
-                self.figure.get_size_inches(),
-            )
 
     def __create_axes(self, grid_shape):
         """

--- a/PQEnalyzer/plots/theme.py
+++ b/PQEnalyzer/plots/theme.py
@@ -111,36 +111,48 @@ def series_rgb(index, appearance_mode=None):
     return tuple(int(color[offset:offset + 2], 16) for offset in (0, 2, 4))
 
 
-def apply_matplotlib_theme(appearance_mode=None):
+def scaled_font_size(font_size, plot_scale=1.0):
+    """
+    Scale one plot font size with the shared plot preference.
+    """
+
+    return round(float(font_size) * float(plot_scale), 2)
+
+
+def apply_matplotlib_theme(appearance_mode=None, plot_scale=1.0):
     """
     Apply a CustomTkinter-aligned palette to matplotlib defaults.
     """
 
     palette = palette_for_appearance_mode(appearance_mode)
+    font_sizes = {
+        name: scaled_font_size(size, plot_scale)
+        for name, size in PLOT_FONT_SIZES.items()
+    }
 
     matplotlib.rcParams.update({
-        "font.size": PLOT_FONT_SIZES["base"],
+        "font.size": font_sizes["base"],
         "figure.facecolor": palette["figure.facecolor"],
         "axes.facecolor": palette["axes.facecolor"],
         "axes.edgecolor": palette["axes.edgecolor"],
         "axes.labelcolor": palette["axes.labelcolor"],
-        "axes.labelsize": PLOT_FONT_SIZES["axis_label"],
+        "axes.labelsize": font_sizes["axis_label"],
         "axes.grid": True,
         "axes.prop_cycle": cycler(color=palette["colors"]),
         "axes.titleweight": "semibold",
-        "axes.titlesize": PLOT_FONT_SIZES["title"],
+        "axes.titlesize": font_sizes["title"],
         "lines.linewidth": 1.45,
         "lines.solid_capstyle": "round",
         "text.color": palette["text.color"],
         "xtick.color": palette["tick.color"],
-        "xtick.labelsize": PLOT_FONT_SIZES["tick"],
+        "xtick.labelsize": font_sizes["tick"],
         "ytick.color": palette["tick.color"],
-        "ytick.labelsize": PLOT_FONT_SIZES["tick"],
+        "ytick.labelsize": font_sizes["tick"],
         "grid.color": palette["grid.color"],
         "grid.alpha": 0.55,
         "legend.facecolor": palette["legend.facecolor"],
         "legend.edgecolor": palette["legend.edgecolor"],
-        "legend.fontsize": PLOT_FONT_SIZES["legend"],
+        "legend.fontsize": font_sizes["legend"],
         "legend.framealpha": 0.95,
         "savefig.facecolor": palette["figure.facecolor"],
     })
@@ -148,24 +160,33 @@ def apply_matplotlib_theme(appearance_mode=None):
     return palette
 
 
-def apply_figure_theme(figure, axes, appearance_mode=None):
+def apply_figure_theme(
+    figure,
+    axes,
+    appearance_mode=None,
+    plot_scale=1.0,
+):
     """
     Apply the active palette to an already-created figure and axes.
     """
 
-    palette = apply_matplotlib_theme(appearance_mode)
+    palette = apply_matplotlib_theme(appearance_mode, plot_scale)
+    font_sizes = {
+        name: scaled_font_size(size, plot_scale)
+        for name, size in PLOT_FONT_SIZES.items()
+    }
 
     figure.patch.set_facecolor(palette["figure.facecolor"])
     axes.set_facecolor(palette["axes.facecolor"])
     axes.grid(True, color=palette["grid.color"], alpha=0.55, linewidth=0.8)
     axes.tick_params(
         colors=palette["tick.color"],
-        labelsize=PLOT_FONT_SIZES["tick"],
+        labelsize=font_sizes["tick"],
     )
     axes.xaxis.label.set_color(palette["axes.labelcolor"])
-    axes.xaxis.label.set_size(PLOT_FONT_SIZES["axis_label"])
+    axes.xaxis.label.set_size(font_sizes["axis_label"])
     axes.yaxis.label.set_color(palette["axes.labelcolor"])
-    axes.yaxis.label.set_size(PLOT_FONT_SIZES["axis_label"])
+    axes.yaxis.label.set_size(font_sizes["axis_label"])
     for title in (
         axes.title,
         getattr(axes, "_left_title", None),
@@ -173,7 +194,7 @@ def apply_figure_theme(figure, axes, appearance_mode=None):
     ):
         if title is not None:
             title.set_color(palette["text.color"])
-            title.set_size(PLOT_FONT_SIZES["title"])
+            title.set_size(font_sizes["title"])
 
     for spine in axes.spines.values():
         spine.set_color(palette["axes.edgecolor"])
@@ -186,8 +207,8 @@ def apply_figure_theme(figure, axes, appearance_mode=None):
         legend.get_frame().set_alpha(0.95)
         for text in legend.get_texts():
             text.set_color(palette["text.color"])
-            text.set_size(PLOT_FONT_SIZES["legend"])
-        legend.get_title().set_size(PLOT_FONT_SIZES["legend"])
+            text.set_size(font_sizes["legend"])
+        legend.get_title().set_size(font_sizes["legend"])
 
     for text in axes.texts:
         text.set_color(palette["text.color"])

--- a/PQEnalyzer/preferences.py
+++ b/PQEnalyzer/preferences.py
@@ -1,0 +1,297 @@
+"""
+Persistent user preferences shared by the GUI and plot windows.
+"""
+
+import contextlib
+from dataclasses import dataclass, field
+import json
+import math
+import os
+from pathlib import Path
+import sys
+
+from ._logging import get_logger
+
+
+logger = get_logger(__name__)
+
+APPEARANCE_MODES = {"System", "Light", "Dark"}
+PLOT_SCALE_PRESETS = (
+    0.75,
+    0.85,
+    0.9,
+    0.95,
+    1.0,
+    1.05,
+    1.1,
+    1.25,
+    1.5,
+    1.75,
+    2.0,
+)
+PLOT_SCALE_LABELS = tuple(
+    f"{scale:.0%}"
+    for scale in PLOT_SCALE_PRESETS
+)
+DEFAULT_PLOT_SCALE = 1.0
+PLOT_SIZE_KEYS = {"single", "dashboard"}
+
+
+@dataclass
+class UserPreferences:
+    """
+    Last user-selected GUI and plot settings.
+    """
+
+    appearance_mode: str = "System"
+    plot_scale: float = DEFAULT_PLOT_SCALE
+    plot_sizes: dict[str, tuple[float, float]] = field(default_factory=dict)
+    selected_parameter: str | None = None
+    auto_refresh: bool = True
+    plot_options: dict = field(default_factory=dict)
+
+    @classmethod
+    def from_mapping(cls, values):
+        """
+        Build validated preferences from decoded JSON-compatible data.
+        """
+
+        if not isinstance(values, dict):
+            return cls()
+
+        appearance_mode = values.get("appearance_mode")
+        if appearance_mode not in APPEARANCE_MODES:
+            appearance_mode = "System"
+
+        selected_parameter = values.get("selected_parameter")
+        if not isinstance(selected_parameter, str) or not selected_parameter:
+            selected_parameter = None
+
+        auto_refresh = values.get("auto_refresh")
+        if not isinstance(auto_refresh, bool):
+            auto_refresh = True
+
+        plot_options = values.get("plot_options")
+        if not isinstance(plot_options, dict):
+            plot_options = {}
+
+        plot_sizes = {}
+        stored_plot_sizes = values.get("plot_sizes")
+        if isinstance(stored_plot_sizes, dict):
+            for key in PLOT_SIZE_KEYS:
+                size = _validated_size(stored_plot_sizes.get(key))
+                if size is not None:
+                    plot_sizes[key] = size
+
+        return cls(
+            appearance_mode=appearance_mode,
+            plot_scale=normalize_plot_scale(
+                values.get("plot_scale", values.get("display_scale"))),
+            plot_sizes=plot_sizes,
+            selected_parameter=selected_parameter,
+            auto_refresh=auto_refresh,
+            plot_options=plot_options,
+        )
+
+    def to_mapping(self):
+        """
+        Return JSON-compatible preference data.
+        """
+
+        return {
+            "appearance_mode": self.appearance_mode,
+            "plot_scale": self.plot_scale,
+            "plot_sizes": {
+                key: list(size)
+                for key, size in self.plot_sizes.items()
+                if key in PLOT_SIZE_KEYS
+            },
+            "selected_parameter": self.selected_parameter,
+            "auto_refresh": self.auto_refresh,
+            "plot_options": self.plot_options,
+        }
+
+
+def normalize_plot_scale(value):
+    """
+    Return the nearest supported plot scale.
+    """
+
+    try:
+        plot_scale = float(value)
+    except (TypeError, ValueError):
+        return DEFAULT_PLOT_SCALE
+
+    if not math.isfinite(plot_scale):
+        return DEFAULT_PLOT_SCALE
+
+    return min(
+        PLOT_SCALE_PRESETS,
+        key=lambda preset: (abs(preset - plot_scale), preset),
+    )
+
+
+def adjusted_plot_scale(current_scale, action):
+    """
+    Return the neighboring preset for an increase, decrease, or reset.
+    """
+
+    if action == "reset":
+        return DEFAULT_PLOT_SCALE
+
+    normalized_scale = normalize_plot_scale(current_scale)
+    current_index = PLOT_SCALE_PRESETS.index(normalized_scale)
+    if action == "increase":
+        target_index = min(current_index + 1, len(PLOT_SCALE_PRESETS) - 1)
+    elif action == "decrease":
+        target_index = max(current_index - 1, 0)
+    else:
+        raise ValueError(f"Unknown plot scale action: {action}")
+
+    return PLOT_SCALE_PRESETS[target_index]
+
+
+def plot_scale_label(plot_scale):
+    """
+    Return a percentage label for one supported plot scale.
+    """
+
+    return f"{normalize_plot_scale(plot_scale):.0%}"
+
+
+def plot_scale_from_label(label):
+    """
+    Return the supported scale represented by a percentage label.
+    """
+
+    if not isinstance(label, str) or not label.endswith("%"):
+        return DEFAULT_PLOT_SCALE
+
+    try:
+        value = float(label[:-1]) / 100
+    except ValueError:
+        return DEFAULT_PLOT_SCALE
+    return normalize_plot_scale(value)
+
+
+def plot_scale_action(key):
+    """
+    Map a Matplotlib key description to a plot-scale action.
+    """
+
+    normalized_key = (key or "").lower()
+    if normalized_key in {
+        "+",
+        "=",
+        "ctrl++",
+        "ctrl+=",
+        "cmd++",
+        "cmd+=",
+    }:
+        return "increase"
+    if normalized_key in {"-", "ctrl+-", "cmd+-"}:
+        return "decrease"
+    if normalized_key in {"0", "ctrl+0", "cmd+0"}:
+        return "reset"
+    return None
+
+
+def preferences_path():
+    """
+    Return the platform-appropriate settings file path.
+    """
+
+    override = os.environ.get("PQENALYZER_CONFIG_DIR")
+    if override:
+        config_directory = Path(override).expanduser()
+    elif sys.platform == "darwin":
+        config_directory = (
+            Path.home() / "Library" / "Application Support" / "PQEnalyzer"
+        )
+    elif sys.platform.startswith("win"):
+        app_data = os.environ.get("APPDATA")
+        config_directory = (
+            Path(app_data)
+            if app_data
+            else Path.home() / "AppData" / "Roaming"
+        ) / "PQEnalyzer"
+    else:
+        config_home = os.environ.get("XDG_CONFIG_HOME")
+        config_directory = (
+            Path(config_home).expanduser()
+            if config_home
+            else Path.home() / ".config"
+        ) / "pqenalyzer"
+
+    return config_directory / "settings.json"
+
+
+def load_preferences(path=None):
+    """
+    Load preferences, returning defaults for missing or invalid files.
+    """
+
+    settings_path = Path(path) if path is not None else preferences_path()
+    try:
+        with settings_path.open("r", encoding="utf-8") as settings_file:
+            values = json.load(settings_file)
+    except FileNotFoundError:
+        return UserPreferences()
+    except (OSError, ValueError) as error:
+        logger.warning("Could not read preferences from %s: %s",
+                       settings_path, error)
+        return UserPreferences()
+
+    return UserPreferences.from_mapping(values)
+
+
+def save_preferences(preferences, path=None):
+    """
+    Atomically save preferences and return whether the write succeeded.
+    """
+
+    settings_path = Path(path) if path is not None else preferences_path()
+    temporary_path = settings_path.with_suffix(".tmp")
+    try:
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        with temporary_path.open("w", encoding="utf-8") as settings_file:
+            json.dump(
+                preferences.to_mapping(),
+                settings_file,
+                indent=2,
+                sort_keys=True,
+            )
+            settings_file.write("\n")
+        temporary_path.replace(settings_path)
+    except OSError as error:
+        with contextlib.suppress(OSError):
+            temporary_path.unlink()
+        logger.warning("Could not save preferences to %s: %s",
+                       settings_path, error)
+        return False
+
+    return True
+
+
+def _validated_size(value):
+    """
+    Return a positive two-dimensional size or ``None``.
+    """
+
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        return None
+
+    try:
+        width, height = (float(dimension) for dimension in value)
+    except (TypeError, ValueError):
+        return None
+
+    if (
+        not math.isfinite(width)
+        or not math.isfinite(height)
+        or width <= 0
+        or height <= 0
+    ):
+        return None
+
+    return round(width, 2), round(height, 2)

--- a/README.md
+++ b/README.md
@@ -88,9 +88,29 @@ Available statistics and overlays are:
 - `Running Average`
 
 Double-click a `Live Monitor` panel to open a focused plot for that parameter.
+Resize a plot window normally and the contents will refit automatically. The
+`Live Monitor` also redistributes its parameter grid between rows and columns
+as the window shape changes without making panels smaller when the window
+grows. At larger text presets, dense dashboards automatically switch to
+compact titles, readouts, and ticks so the data area remains readable. Press
+`f` in the `Live Monitor` to fit it to the current screen.
+
+Choose an exact `Plot Size` percentage in the GUI sidebar. In a plot window,
+`+` and `-` move through the same presets and `Ctrl+0` or `Command+0` restores
+`100%`. Plot sizing does not change the fixed selection window. PQEnalyzer
+remembers the theme, plot size, plot window dimensions, selected parameter,
+auto-refresh state, statistics, overlays, raw-data visibility, and
+running-average window for the next launch.
+
 When `Difference (1 - 2)` is enabled, PQEnalyzer compares the first file against
 the second file and hides the raw data by default so the difference is easier to
 read.
+
+Settings are stored in `settings.json` under the platform user-config
+directory: `~/Library/Application Support/PQEnalyzer` on macOS,
+`$XDG_CONFIG_HOME/pqenalyzer` (or `~/.config/pqenalyzer`) on Linux, and
+`%APPDATA%\PQEnalyzer` on Windows. Set `PQENALYZER_CONFIG_DIR` to override that
+directory.
 
 ### TUI
 

--- a/tests/apps/test_app.py
+++ b/tests/apps/test_app.py
@@ -6,6 +6,7 @@ import pytest
 
 from PQEnalyzer.apps import app as app_module
 from PQEnalyzer.apps import app_layout
+from PQEnalyzer.preferences import UserPreferences
 from PQEnalyzer.plots.options import PlotOptions
 
 
@@ -108,13 +109,19 @@ def reset_dummy_plots():
 
 def make_app(auto_refresh=True):
     app = object.__new__(app_module.App)
+    app.preferences = UserPreferences()
+    app.appearance_mode_setting = "System"
+    app.appearance_mode = "Light"
+    app.plot_scale = 1.0
     app.auto_refresh = FakeFlag(auto_refresh)
     app.reader = SimpleNamespace(filenames=["/tmp/md.en"])
     app.list_of_plots = []
     app.selected_plot = None
     app._App__syncing_plot_controls = False
+    app._App__restoring_preferences = False
     app._App__file_watcher = None
     app._App__auto_refresh_after_id = None
+    app._App__preferences_after_id = None
     app._App__selected_info = "TEMPERATURE"
     app.after = lambda delay, callback: "after-id"
     app.after_cancel = lambda after_id: None
@@ -136,6 +143,83 @@ def test_apps_package_does_not_import_gui_module_for_terminal_app():
 
 def test_gui_icon_path_resolves_from_layout_module():
     assert app_layout.ICON_PATH.is_file()
+
+
+def test_default_theme_applies_persisted_mode_without_gui_scaling(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        app_layout.ctk,
+        "set_appearance_mode",
+        lambda value: calls.append(("appearance", value)),
+    )
+    monkeypatch.setattr(
+        app_layout.ctk,
+        "set_default_color_theme",
+        lambda value: calls.append(("color", value)),
+    )
+    app_layout.configure_default_theme("Dark")
+
+    assert calls == [
+        ("appearance", "Dark"),
+        ("color", "blue"),
+    ]
+
+
+def test_selector_window_keeps_fixed_layout(monkeypatch):
+    calls = []
+
+    class FakeWindow:
+
+        def title(self, value):
+            calls.append(("title", value))
+
+        def iconphoto(self, *values):
+            calls.append(("icon", values))
+
+        def resizable(self, *values):
+            calls.append(("resizable", values))
+
+    monkeypatch.setattr(app_layout.Image, "open", lambda path: "image")
+    monkeypatch.setattr(
+        app_layout.ImageTk,
+        "PhotoImage",
+        lambda image: "photo",
+    )
+
+    app_layout.configure_window(FakeWindow())
+
+    assert ("resizable", (False, False)) in calls
+
+
+def test_sidebar_exposes_exact_plot_scale_presets(monkeypatch):
+    app = SimpleNamespace(
+        plot_scale=1.05,
+        appearance_mode_setting="Dark",
+    )
+    scale_selections = []
+
+    monkeypatch.setattr(app_layout.ctk, "CTkFrame", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkLabel", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkButton", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkOptionMenu", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkImage", FakeWidget)
+    monkeypatch.setattr(app_layout.ctk, "CTkFont", FakeWidget)
+    monkeypatch.setattr(app_layout.Image, "open", lambda path: "image")
+
+    view = app_layout.SidebarView(
+        app,
+        lambda mode: None,
+        scale_selections.append,
+    )
+    view.plot_scale_optionemenu.kwargs["command"]("100%")
+
+    assert scale_selections == ["100%"]
+    assert "95%" in view.plot_scale_optionemenu.kwargs["values"]
+    assert "100%" in view.plot_scale_optionemenu.kwargs["values"]
+    assert "105%" in view.plot_scale_optionemenu.kwargs["values"]
+    assert view.plot_scale_optionemenu.value == "105%"
+    assert view.appearance_mode_optionemenu.value == "Dark"
+    assert app.plot_scale_optionemenu is view.plot_scale_optionemenu
 
 
 @pytest.mark.parametrize(
@@ -519,17 +603,145 @@ def test_change_appearance_mode_updates_matplotlib_and_open_plots(monkeypatch):
                         lambda mode: calls.append(("ctk", mode)))
     monkeypatch.setattr(app_module, "resolve_appearance_mode",
                         lambda mode: "Dark")
-    monkeypatch.setattr(app_module, "apply_matplotlib_theme",
-                        lambda mode: calls.append(("mpl", mode)))
+    monkeypatch.setattr(
+        app_module,
+        "apply_matplotlib_theme",
+        lambda mode, scale: calls.append(("mpl", mode, scale)),
+    )
     monkeypatch.setattr(app_module.plt, "get_fignums", lambda: [1])
 
     app_module.App._App__change_appearance_mode_event(app, "Dark")
 
     assert app.appearance_mode == "Dark"
+    assert app.appearance_mode_setting == "Dark"
     assert app.list_of_plots == [open_plot]
-    assert calls == [("ctk", "Dark"), ("mpl", "Dark"), ("redraw", 1)]
+    assert calls == [
+        ("ctk", "Dark"),
+        ("mpl", "Dark", 1.0),
+        ("redraw", 1),
+    ]
 
 
+def test_plot_scale_updates_plots_and_preset_without_scaling_gui(monkeypatch):
+    app = make_app()
+    app.plot_scale_optionemenu = FakeWidget()
+    calls = []
+
+    monkeypatch.setattr(
+        app_module,
+        "apply_matplotlib_theme",
+        lambda mode, scale: calls.append(("plots", mode, scale)),
+    )
+
+    app_module.App.change_plot_scale(app, "increase")
+
+    assert app.plot_scale == 1.05
+    assert app.plot_scale_optionemenu.value == "105%"
+    assert calls == [("plots", "Light", 1.05)]
+
+    app_module.App.change_plot_scale(app, "95%")
+    assert app.plot_scale == 0.95
+    assert app.plot_scale_optionemenu.value == "95%"
+
+    app.plot_scale = 2.0
+    assert app_module.App.change_plot_scale(app, "increase") is None
+
+
+def test_plot_window_sizes_are_restored_and_remembered():
+    app = make_app()
+    app.preferences.plot_sizes["single"] = (12.0, 8.0)
+
+    assert app_module.App.plot_size(app, "single", (11, 7)) == (12.0, 8.0)
+    assert app_module.App.plot_size(app, "dashboard", (15, 9.5)) == (
+        15,
+        9.5,
+    )
+
+    app_module.App.remember_plot_size(app, "dashboard", (14.22, 8.88))
+    assert app.preferences.plot_sizes["dashboard"] == (14.22, 8.88)
+    assert app_module.App.remember_plot_size(
+        app,
+        "dashboard",
+        (float("nan"), 8),
+    ) is None
+
+    with pytest.raises(ValueError, match="Unknown plot kind"):
+        app_module.App.remember_plot_size(app, "other", (10, 8))
+
+
+def test_preferences_restore_controls_valid_for_current_files():
+    app = make_app(auto_refresh=True)
+    app.info = ["TEMPERATURE", "PRESSURE"]
+    app.preferences = UserPreferences(
+        appearance_mode="Dark",
+        plot_scale=1.25,
+        selected_parameter="PRESSURE",
+        auto_refresh=False,
+        plot_options=PlotOptions(
+            mean=True,
+            running_average=True,
+            window_size="20",
+            plot_main=True,
+        ).to_mapping(),
+    )
+    app.appearance_mode_setting = "Dark"
+    app.plot_scale = 1.25
+    app.mean = FakeFlag(False)
+    app.median = FakeFlag(False)
+    app.cummulative_average = FakeFlag(False)
+    app.self_correlation_mean = FakeFlag(False)
+    app.difference = FakeFlag(False)
+    app.running_average = FakeFlag(False)
+    app.plot_main_data = FakeFlag(False)
+    app.window_size = FakeEntry("")
+    app.info_optionmenu = FakeWidget()
+    app.plot_scale_optionemenu = FakeWidget()
+    app.appearance_mode_optionemenu = FakeWidget()
+
+    app_module.App._App__restore_preferences(app)
+
+    assert app.auto_refresh.value is False
+    assert app.mean.value is True
+    assert app.running_average.value is True
+    assert app.plot_main_data.value is True
+    assert app.window_size.value == "20"
+    assert app._App__selected_info == "PRESSURE"
+    assert app.info_optionmenu.value == "PRESSURE"
+    assert app.plot_scale_optionemenu.value == "125%"
+    assert app.appearance_mode_optionemenu.value == "Dark"
+
+
+def test_preferences_capture_and_write_all_gui_controls(monkeypatch):
+    app = make_app(auto_refresh=False)
+    app.appearance_mode_setting = "Light"
+    app.plot_scale = 1.5
+    app._App__selected_info = "PRESSURE"
+    app.mean = FakeFlag(True)
+    app.median = FakeFlag(False)
+    app.cummulative_average = FakeFlag(False)
+    app.self_correlation_mean = FakeFlag(False)
+    app.difference = FakeFlag(False)
+    app.running_average = FakeFlag(True)
+    app.plot_main_data = FakeFlag(True)
+    app.window_size = FakeEntry("30")
+    saved = []
+    monkeypatch.setattr(
+        app_module,
+        "save_preferences",
+        lambda user_preferences: saved.append(user_preferences.to_mapping())
+        or True,
+    )
+
+    assert app_module.App._App__write_preferences(app) is True
+
+    assert app.preferences.appearance_mode == "Light"
+    assert app.preferences.plot_scale == 1.5
+    assert app.preferences.selected_parameter == "PRESSURE"
+    assert app.preferences.auto_refresh is False
+    assert app.preferences.plot_options["mean"] is True
+    assert app.preferences.plot_options["running_average"] is True
+    assert app.preferences.plot_options["window_size"] == "30"
+    assert len(saved) == 1
 def test_select_plot_syncs_plot_options_to_controls(monkeypatch):
     app = make_app()
     app.mean = FakeFlag(False)

--- a/tests/e2e/test_cli_modes.py
+++ b/tests/e2e/test_cli_modes.py
@@ -2,6 +2,7 @@ import os
 import select
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -22,6 +23,10 @@ def _subprocess_environment():
     env.setdefault("TERM", "xterm-256color")
     env.setdefault("COLUMNS", "100")
     env.setdefault("LINES", "40")
+    env.setdefault(
+        "PQENALYZER_CONFIG_DIR",
+        str(Path(tempfile.gettempdir()) / f"pqenalyzer-tests-{os.getpid()}"),
+    )
     return env
 
 

--- a/tests/plots/test_features.py
+++ b/tests/plots/test_features.py
@@ -52,6 +52,30 @@ def test_plot_options_can_read_registry_feature_defaults():
         del PLOT_FEATURES_BY_KEY["temporary_feature"]
 
 
+def test_plot_options_restore_and_serialize_known_values():
+    options = PlotOptions.from_mapping({
+        "mean": True,
+        "median": "yes",
+        "window_size": "25",
+        "unknown": True,
+    })
+
+    assert options.mean is True
+    assert options.median is False
+    assert options.window_size == "25"
+    assert options.to_mapping() == {
+        "mean": True,
+        "median": False,
+        "cummulative_average": False,
+        "self_correlation_mean": False,
+        "difference": False,
+        "running_average": False,
+        "window_size": "25",
+        "plot_main": False,
+    }
+    assert PlotOptions.from_mapping(None) == PlotOptions()
+
+
 def test_time_series_overlay_evaluator_uses_enabled_features():
     options = PlotOptions.with_enabled(
         "mean",

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -1,6 +1,8 @@
+import math
+from types import SimpleNamespace
+
 import numpy as np
 import matplotlib.pyplot as plt
-from types import SimpleNamespace
 
 from PQEnalyzer.plots.plot_dashboard import PlotDashboard
 from PQEnalyzer.plots.plot_histogram import PlotHistogram
@@ -148,12 +150,26 @@ class FakeApp:
         self.info = ["TEMPERATURE", "PRESSURE"]
         self.focus_calls = []
         self.appearance_mode = "Light"
+        self.plot_scale = 1.0
+        self.scale_actions = []
+        self.remembered_plot_sizes = {}
+        self.preferences = SimpleNamespace(
+            plot_sizes=self.remembered_plot_sizes)
 
     def select_plot(self, plot):
         self.selected_plot = plot
 
     def open_focus_plot(self, parameter):
         self.focus_calls.append(parameter)
+
+    def change_plot_scale(self, action):
+        self.scale_actions.append(action)
+
+    def plot_size(self, plot_kind, default):
+        return self.remembered_plot_sizes.get(plot_kind, default)
+
+    def remember_plot_size(self, plot_kind, size):
+        self.remembered_plot_sizes[plot_kind] = tuple(size)
 
 
 def teardown_function():
@@ -285,6 +301,46 @@ def test_single_plot_uses_roomier_initial_window_size():
         plot.figure.get_size_inches(),
         SINGLE_PLOT_FIGURE_SIZE,
     )
+
+
+def test_single_plot_restores_and_remembers_resized_window():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])])
+    app.remembered_plot_sizes["single"] = (9.5, 6.5)
+    plot = PlotTime(app)
+
+    np.testing.assert_allclose(plot.figure.get_size_inches(), (9.5, 6.5))
+
+    plot.figure.set_size_inches(12, 8)
+    plot._Plot__resize_event(SimpleNamespace())
+
+    np.testing.assert_allclose(
+        app.remembered_plot_sizes["single"],
+        (12, 8),
+    )
+
+
+def test_single_plot_keyboard_shortcuts_change_plot_scale():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])])
+    plot = PlotTime(app)
+
+    plot._Plot__key_press_event(SimpleNamespace(key="+"))
+    plot._Plot__key_press_event(SimpleNamespace(key="cmd+-"))
+    plot._Plot__key_press_event(SimpleNamespace(key="x"))
+
+    assert app.scale_actions == ["increase", "decrease"]
+
+
+def test_single_plot_typography_uses_app_plot_scale():
+    app = FakeApp([FakeEnergy([1, 2, 3, 4])])
+    app.plot_scale = 1.5
+    plot = PlotTime(app)
+    plot.info_parameter = "PARAMETER"
+
+    plot.plot_data()
+
+    assert plot.ax._left_title.get_size() == 24
+    assert plot.ax.xaxis.label.get_size() == 21
+    assert plot.ax.get_xticklabels()[0].get_size() == 18
 
 
 def test_time_labels_use_time_series_title_and_parameter_axis():
@@ -565,6 +621,165 @@ def test_dashboard_bounds_large_parameter_grid_to_screen_shape():
     assert plot._PlotDashboard__grid_shape() == (5, 5)
     assert tuple(plot.figure.get_size_inches()) == (15.0, 9.5)
     assert len(plot.axes) == 25
+
+
+def test_dashboard_reflows_grid_when_window_shape_changes():
+    energy = FakeLargeDashboardEnergy()
+    app = FakeApp([energy])
+    app.info = energy.parameters
+    plot = PlotDashboard(app)
+
+    plot.figure.set_size_inches(6, 10)
+    plot._PlotDashboard__resize_event(
+        SimpleNamespace(width=600, height=1000))
+
+    assert plot._PlotDashboard__grid_shape() == (7, 3)
+    assert plot._grid_shape == (7, 3)
+    assert len(plot.axes) == 21
+
+    plot.figure.set_size_inches(16, 6)
+    plot._PlotDashboard__resize_event(
+        SimpleNamespace(width=1600, height=600))
+
+    assert plot._PlotDashboard__grid_shape() == (4, 6)
+    assert plot._grid_shape == (4, 6)
+    assert len(plot.axes) == 24
+    np.testing.assert_allclose(
+        app.remembered_plot_sizes["dashboard"],
+        (16, 6),
+    )
+
+
+def test_dashboard_growth_never_reduces_average_panel_area():
+    energy = FakeLargeDashboardEnergy(number_of_parameters=11)
+    app = FakeApp([energy])
+    app.info = energy.parameters
+    plot = PlotDashboard(app)
+
+    assert plot._grid_shape == (3, 4)
+    old_panel_area = (
+        plot._canvas_size[0]
+        * plot._canvas_size[1]
+        / math.prod(plot._grid_shape)
+    )
+
+    plot.figure.set_size_inches(16, 6.5)
+    plot._PlotDashboard__resize_event(
+        SimpleNamespace(width=1600, height=650))
+
+    new_panel_area = 1600 * 650 / math.prod(plot._grid_shape)
+    assert plot._grid_shape == (3, 4)
+    assert new_panel_area >= old_panel_area
+
+
+def test_dashboard_updates_compact_typography_without_grid_change():
+    energy = FakeLargeDashboardEnergy(number_of_parameters=11)
+    app = FakeApp([energy])
+    app.info = energy.parameters
+    app.plot_scale = 2.0
+    plot = PlotDashboard(app)
+    plot.redraw()
+    initial_font_size = plot.axes[0]._left_title.get_fontsize()
+    plot.figure.canvas.draw()
+    renderer = plot.figure.canvas.get_renderer()
+    initial_bounds = plot.axes[0].get_window_extent(renderer)
+    initial_panel_area = initial_bounds.width * initial_bounds.height
+
+    plot.figure.set_size_inches(15, 9)
+    plot._PlotDashboard__resize_event(
+        SimpleNamespace(width=1500, height=900))
+    plot.figure.canvas.draw()
+    resized_bounds = plot.axes[0].get_window_extent(
+        plot.figure.canvas.get_renderer())
+    resized_panel_area = resized_bounds.width * resized_bounds.height
+
+    assert plot._grid_shape == (3, 4)
+    assert plot._panel_scale == 1.4
+    assert plot.axes[0]._left_title.get_fontsize() > initial_font_size
+    assert resized_panel_area >= initial_panel_area
+
+
+def test_dashboard_switches_dense_large_text_to_compact_labels():
+    energy = FakeLargeDashboardEnergy()
+    app = FakeApp([energy])
+    app.info = energy.parameters
+    app.plot_scale = 2.0
+
+    plot = PlotDashboard(app)
+    plot.redraw()
+
+    assert plot._grid_shape == (5, 5)
+    assert plot._compact_labels is True
+    assert plot._panel_scale == 1.0
+    assert plot.axes[0].get_title(loc="left") == "PARAMETER-00"
+    assert plot.axes[0]._left_title.get_fontsize() == 9
+    assert plot.axes[0].texts[0].get_fontsize() == 7.5
+    assert plot.figure._suptitle.get_fontsize() == 21
+    assert all(
+        not label.get_visible()
+        for label in plot.axes[0].get_xticklabels()
+    )
+    assert all(
+        label.get_visible()
+        for label in plot.axes[20].get_xticklabels()
+    )
+
+    plot.figure.canvas.draw()
+    renderer = plot.figure.canvas.get_renderer()
+    panel_bounds = [
+        ax.get_window_extent(renderer)
+        for ax in plot.axes[:len(plot.parameters)]
+    ]
+    assert min(bounds.width for bounds in panel_bounds) > 200
+    assert min(bounds.height for bounds in panel_bounds) > 90
+
+
+def test_dashboard_compacts_multi_file_readout_at_large_scale():
+    first = FakeDashboardEnergy()
+    second = FakeDashboardEnergy()
+    second.data["TEMPERATURE"] = np.array([301.0, 303.0, 304.0])
+    second.simulation_time = second.data["SIMULATION-TIME"]
+    app = FakeApp([first, second])
+    app.plot_scale = 2.0
+    plot = PlotDashboard(app)
+
+    plot.redraw()
+
+    assert plot._compact_labels is True
+    assert plot.axes[0].get_title(loc="left") == "TEMPERATURE"
+    assert plot.axes[0].texts[0].get_text() == "302 K | +1"
+
+
+def test_dashboard_keyboard_shortcuts_change_plot_scale():
+    app = FakeApp([FakeDashboardEnergy()])
+    plot = PlotDashboard(app)
+
+    plot._PlotDashboard__key_press_event(SimpleNamespace(key="ctrl+="))
+    plot._PlotDashboard__key_press_event(SimpleNamespace(key="0"))
+    plot._PlotDashboard__key_press_event(SimpleNamespace(key="x"))
+
+    assert app.scale_actions == ["increase", "reset"]
+
+
+def test_dashboard_fit_to_screen_uses_native_window_geometry():
+    app = FakeApp([FakeDashboardEnergy()])
+    plot = PlotDashboard(app)
+    geometries = []
+    window = SimpleNamespace(
+        winfo_screenwidth=lambda: 1920,
+        winfo_screenheight=lambda: 1080,
+        geometry=geometries.append,
+    )
+    plot.figure.canvas.manager = SimpleNamespace(window=window)
+
+    assert plot.fit_to_screen() is True
+    assert geometries == ["1824x972+48+54"]
+
+    plot._PlotDashboard__key_press_event(SimpleNamespace(key="f"))
+    assert geometries == [
+        "1824x972+48+54",
+        "1824x972+48+54",
+    ]
 
 
 def test_dashboard_uses_custom_independent_axis_label():

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -74,6 +74,32 @@ class FakeDashboardEnergy:
         self.simulation_time = self.data["SIMULATION-TIME"]
 
 
+class FakeLargeDashboardEnergy:
+
+    def __init__(self, number_of_parameters=21):
+        parameters = [
+            f"PARAMETER-{index:02d}"
+            for index in range(number_of_parameters)
+        ]
+        self.info = {
+            "SIMULATION-TIME": "SIMULATION-TIME",
+            **{parameter: parameter for parameter in parameters},
+        }
+        self.units = {
+            "SIMULATION-TIME": "step",
+            **{parameter: "unit" for parameter in parameters},
+        }
+        self.data = {
+            "SIMULATION-TIME": np.array([1, 2, 3]),
+            **{
+                parameter: np.array([index, index + 1, index + 2])
+                for index, parameter in enumerate(parameters)
+            },
+        }
+        self.simulation_time = self.data["SIMULATION-TIME"]
+        self.parameters = parameters
+
+
 class FakeReader:
 
     def __init__(self, energies, filenames=None):
@@ -479,13 +505,66 @@ def test_dashboard_plots_all_parameters_as_raw_overview():
     assert plot.axis_parameters[plot.axes[1]] == "PRESSURE"
     assert plot.axes[0].get_title(loc="left") == "TEMPERATURE / K"
     assert plot.axes[1].get_title(loc="left") == "PRESSURE / bar"
-    assert plot.axes[0].get_title(loc="right") == "302 K"
-    assert plot.axes[1].get_title(loc="right") == "1.25 bar"
+    assert plot.axes[0].get_title(loc="right") == ""
+    assert plot.axes[1].get_title(loc="right") == ""
     assert len(plot.axes[0].lines) == 1
     assert len(plot.axes[1].lines) == 1
-    assert len(plot.axes[0].texts) == 0
-    assert len(plot.axes[1].texts) == 0
+    assert [text.get_text() for text in plot.axes[0].texts] == ["302 K"]
+    assert [text.get_text() for text in plot.axes[1].texts] == ["1.25 bar"]
     assert len(plot.figure.legends) == 1
+
+
+def test_dashboard_preserves_compact_panel_typography():
+    plot = PlotDashboard(FakeApp([FakeDashboardEnergy()]))
+
+    plot.redraw()
+
+    assert plot.axes[0]._left_title.get_fontsize() == 9
+    assert plot.axes[0]._left_title.get_fontweight() == "normal"
+    assert {
+        tick.get_fontsize()
+        for tick in plot.axes[0].get_xticklabels()
+    } == {8}
+    assert {
+        tick.get_fontsize()
+        for tick in plot.axes[0].get_yticklabels()
+    } == {8}
+
+
+def test_dashboard_places_latest_value_inside_panel():
+    plot = PlotDashboard(FakeApp([FakeDashboardEnergy()]))
+
+    plot.redraw()
+    plot.figure.canvas.draw()
+
+    readout = plot.axes[0].texts[0]
+    assert readout.get_position() == (0.985, 0.965)
+    assert readout.get_horizontalalignment() == "right"
+    assert readout.get_verticalalignment() == "top"
+    assert readout.get_transform() == plot.axes[0].transAxes
+    assert readout.get_bbox_patch() is not None
+
+    renderer = plot.figure.canvas.get_renderer()
+    axes_bounds = plot.axes[0].get_window_extent(renderer)
+    readout_bounds = readout.get_bbox_patch().get_window_extent(renderer)
+    title_bounds = plot.axes[0]._left_title.get_window_extent(renderer)
+    assert readout_bounds.x0 >= axes_bounds.x0
+    assert readout_bounds.x1 <= axes_bounds.x1
+    assert readout_bounds.y0 >= axes_bounds.y0
+    assert readout_bounds.y1 <= axes_bounds.y1
+    assert not readout_bounds.overlaps(title_bounds)
+
+
+def test_dashboard_bounds_large_parameter_grid_to_screen_shape():
+    energy = FakeLargeDashboardEnergy()
+    app = FakeApp([energy])
+    app.info = energy.parameters
+
+    plot = PlotDashboard(app)
+
+    assert plot._PlotDashboard__grid_shape() == (5, 5)
+    assert tuple(plot.figure.get_size_inches()) == (15.0, 9.5)
+    assert len(plot.axes) == 25
 
 
 def test_dashboard_uses_custom_independent_axis_label():
@@ -512,7 +591,7 @@ def test_dashboard_omits_missing_qmcfc_units_from_titles():
     assert plot.axes[1].get_title(loc="left") == "PRESSURE"
 
 
-def test_dashboard_uses_compact_latest_titles_for_multiple_files():
+def test_dashboard_uses_compact_latest_readouts_for_multiple_files():
     first = FakeDashboardEnergy()
     second = FakeDashboardEnergy()
     second.data["TEMPERATURE"] = np.array([301.0, 303.0, 304.0])
@@ -522,7 +601,8 @@ def test_dashboard_uses_compact_latest_titles_for_multiple_files():
 
     plot.redraw()
 
-    assert plot.axes[0].get_title(loc="right") == "302 | 304 K"
+    assert plot.axes[0].get_title(loc="right") == ""
+    assert plot.axes[0].texts[0].get_text() == "302 | 304 K"
 
 
 def test_dashboard_keeps_file_colors_when_a_parameter_is_missing():

--- a/tests/plots/test_gui_plots.py
+++ b/tests/plots/test_gui_plots.py
@@ -172,6 +172,22 @@ class FakeApp:
         self.remembered_plot_sizes[plot_kind] = tuple(size)
 
 
+class FakeScheduledApp(FakeApp):
+
+    def __init__(self, energies):
+        super().__init__(energies)
+        self.after_calls = []
+        self.cancelled_after_ids = []
+
+    def after(self, delay, callback):
+        after_id = f"after-{len(self.after_calls)}"
+        self.after_calls.append((after_id, delay, callback))
+        return after_id
+
+    def after_cancel(self, after_id):
+        self.cancelled_after_ids.append(after_id)
+
+
 def teardown_function():
     plt.close("all")
 
@@ -648,6 +664,37 @@ def test_dashboard_reflows_grid_when_window_shape_changes():
         app.remembered_plot_sizes["dashboard"],
         (16, 6),
     )
+
+
+def test_dashboard_coalesces_rapid_native_resize_events():
+    energy = FakeLargeDashboardEnergy()
+    app = FakeScheduledApp([energy])
+    app.info = energy.parameters
+    plot = PlotDashboard(app)
+
+    plot.figure.set_size_inches(6, 10)
+    plot._PlotDashboard__resize_event(
+        SimpleNamespace(width=600, height=1000))
+    first_after_id, delay, _ = app.after_calls[-1]
+
+    plot.figure.set_size_inches(16, 6)
+    plot._PlotDashboard__resize_event(
+        SimpleNamespace(width=1600, height=600))
+    _, _, final_callback = app.after_calls[-1]
+
+    assert delay == 120
+    assert app.cancelled_after_ids == [first_after_id]
+    assert plot._grid_shape == (5, 5)
+    np.testing.assert_allclose(
+        app.remembered_plot_sizes["dashboard"],
+        (16, 6),
+    )
+
+    final_callback()
+
+    assert plot._grid_shape == (4, 6)
+    assert plot._pending_resize is None
+    assert plot._resize_after_id is None
 
 
 def test_dashboard_growth_never_reduces_average_panel_area():

--- a/tests/plots/test_theme.py
+++ b/tests/plots/test_theme.py
@@ -31,6 +31,16 @@ def test_apply_matplotlib_theme_sets_dark_defaults():
             "legend"]
 
 
+def test_plot_typography_uses_shared_plot_scale():
+    with mpl.rc_context():
+        theme.apply_matplotlib_theme("Light", 1.5)
+
+        assert mpl.rcParams["axes.titlesize"] == 24
+        assert mpl.rcParams["axes.labelsize"] == 21
+        assert mpl.rcParams["xtick.labelsize"] == 18
+        assert theme.scaled_font_size(9, 1.5) == 13.5
+
+
 def test_series_colors_are_stable_by_file_index():
     assert theme.series_color(1, "Light") == theme.LIGHT_PALETTE["colors"][1]
     assert theme.series_color(9, "Light") == theme.LIGHT_PALETTE["colors"][1]
@@ -72,3 +82,20 @@ def test_apply_figure_theme_updates_existing_plot_elements():
         assert legend_text.get_size() == theme.PLOT_FONT_SIZES["legend"]
         assert axes.texts[0].get_color() == palette["text.color"]
         assert axes.texts[0].get_bbox_patch().get_alpha() == 0.85
+
+
+def test_apply_figure_theme_scales_existing_plot_elements():
+    with mpl.rc_context():
+        figure, axes = plt.subplots()
+        axes.set_title("Scaled", loc="left")
+        axes.set_xlabel("Step")
+        axes.set_ylabel("Value")
+        axes.plot([1, 2], [3, 4], label="data")
+        axes.legend()
+
+        theme.apply_figure_theme(figure, axes, "Light", 1.25)
+
+        assert axes._left_title.get_size() == 20
+        assert axes.xaxis.label.get_size() == 17.5
+        assert axes.get_xticklabels()[0].get_size() == 15
+        assert axes.get_legend().get_texts()[0].get_size() == 15

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -1,0 +1,241 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from PQEnalyzer import preferences
+
+
+def test_preferences_round_trip_valid_values():
+    stored = {
+        "appearance_mode": "Dark",
+        "plot_scale": 1.5,
+        "plot_sizes": {
+            "single": [12.5, 8],
+            "dashboard": [15, 9.5],
+            "unknown": [1, 1],
+        },
+        "selected_parameter": "TEMPERATURE",
+        "auto_refresh": False,
+        "plot_options": {
+            "mean": True,
+            "window_size": "25",
+        },
+    }
+
+    user_preferences = preferences.UserPreferences.from_mapping(stored)
+
+    assert user_preferences.appearance_mode == "Dark"
+    assert user_preferences.plot_scale == 1.5
+    assert user_preferences.plot_sizes == {
+        "single": (12.5, 8.0),
+        "dashboard": (15.0, 9.5),
+    }
+    assert user_preferences.selected_parameter == "TEMPERATURE"
+    assert user_preferences.auto_refresh is False
+    assert user_preferences.plot_options["mean"] is True
+    assert user_preferences.to_mapping() == {
+        "appearance_mode": "Dark",
+        "plot_scale": 1.5,
+        "plot_sizes": {
+            "single": [12.5, 8.0],
+            "dashboard": [15.0, 9.5],
+        },
+        "selected_parameter": "TEMPERATURE",
+        "auto_refresh": False,
+        "plot_options": {
+            "mean": True,
+            "window_size": "25",
+        },
+    }
+
+
+def test_preferences_replace_invalid_values_with_defaults():
+    user_preferences = preferences.UserPreferences.from_mapping({
+        "appearance_mode": "Sepia",
+        "plot_scale": float("nan"),
+        "plot_sizes": {
+            "single": [-1, 8],
+            "dashboard": "large",
+        },
+        "selected_parameter": "",
+        "auto_refresh": "yes",
+        "plot_options": [],
+    })
+
+    assert user_preferences == preferences.UserPreferences()
+    assert preferences.UserPreferences.from_mapping(None) == (
+        preferences.UserPreferences()
+    )
+
+
+def test_preferences_migrate_legacy_display_scale_without_gui_size():
+    user_preferences = preferences.UserPreferences.from_mapping({
+        "display_scale": 1.05,
+        "gui_size": [900, 700],
+    })
+
+    assert user_preferences.plot_scale == 1.05
+    assert "gui_size" not in user_preferences.to_mapping()
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, 1.0),
+        ("large", 1.0),
+        (float("inf"), 1.0),
+        (0.1, 0.75),
+        (1.333, 1.25),
+        (4, 2.0),
+    ],
+)
+def test_normalize_plot_scale(value, expected):
+    assert preferences.normalize_plot_scale(value) == expected
+
+
+def test_adjusted_plot_scale_uses_exact_neighboring_presets():
+    assert preferences.adjusted_plot_scale(0.95, "increase") == 1.0
+    assert preferences.adjusted_plot_scale(1.0, "increase") == 1.05
+    assert preferences.adjusted_plot_scale(1.05, "decrease") == 1.0
+    assert preferences.adjusted_plot_scale(1.0, "decrease") == 0.95
+    assert preferences.adjusted_plot_scale(2.0, "increase") == 2.0
+    assert preferences.adjusted_plot_scale(1.7, "reset") == 1.0
+
+    with pytest.raises(ValueError, match="Unknown plot scale action"):
+        preferences.adjusted_plot_scale(1.0, "larger")
+
+
+def test_plot_scale_labels_round_trip_supported_presets():
+    assert preferences.plot_scale_label(0.95) == "95%"
+    assert preferences.plot_scale_label(1.0) == "100%"
+    assert preferences.plot_scale_label(1.05) == "105%"
+    assert preferences.plot_scale_from_label("105%") == 1.05
+    assert preferences.plot_scale_from_label("invalid") == 1.0
+    assert preferences.plot_scale_from_label("large%") == 1.0
+
+
+@pytest.mark.parametrize(
+    "key, expected",
+    [
+        ("+", "increase"),
+        ("=", "increase"),
+        ("CTRL++", "increase"),
+        ("cmd+=", "increase"),
+        ("-", "decrease"),
+        ("ctrl+-", "decrease"),
+        ("0", "reset"),
+        ("cmd+0", "reset"),
+        ("x", None),
+        (None, None),
+    ],
+)
+def test_plot_scale_action(key, expected):
+    assert preferences.plot_scale_action(key) == expected
+
+
+def test_preferences_path_uses_override(monkeypatch, tmp_path):
+    monkeypatch.setenv("PQENALYZER_CONFIG_DIR", str(tmp_path))
+
+    assert preferences.preferences_path() == tmp_path / "settings.json"
+
+
+def test_preferences_path_uses_macos_application_support(monkeypatch):
+    monkeypatch.delenv("PQENALYZER_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(preferences.sys, "platform", "darwin")
+
+    assert preferences.preferences_path() == (
+        Path.home()
+        / "Library"
+        / "Application Support"
+        / "PQEnalyzer"
+        / "settings.json"
+    )
+
+
+def test_preferences_path_uses_windows_app_data(monkeypatch, tmp_path):
+    monkeypatch.delenv("PQENALYZER_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(preferences.sys, "platform", "win32")
+    monkeypatch.setenv("APPDATA", str(tmp_path))
+
+    assert preferences.preferences_path() == (
+        tmp_path / "PQEnalyzer" / "settings.json"
+    )
+
+    monkeypatch.delenv("APPDATA")
+    assert preferences.preferences_path() == (
+        Path.home()
+        / "AppData"
+        / "Roaming"
+        / "PQEnalyzer"
+        / "settings.json"
+    )
+
+
+def test_preferences_path_uses_xdg_or_linux_default(monkeypatch, tmp_path):
+    monkeypatch.delenv("PQENALYZER_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(preferences.sys, "platform", "linux")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+    assert preferences.preferences_path() == (
+        tmp_path / "pqenalyzer" / "settings.json"
+    )
+
+    monkeypatch.delenv("XDG_CONFIG_HOME")
+    assert preferences.preferences_path() == (
+        Path.home() / ".config" / "pqenalyzer" / "settings.json"
+    )
+
+
+def test_save_and_load_preferences(tmp_path):
+    settings_path = tmp_path / "nested" / "settings.json"
+    expected = preferences.UserPreferences(
+        appearance_mode="Light",
+        plot_scale=1.25,
+    )
+
+    assert preferences.save_preferences(expected, settings_path) is True
+    assert preferences.load_preferences(settings_path) == expected
+    assert json.loads(settings_path.read_text(encoding="utf-8"))[
+        "appearance_mode"
+    ] == "Light"
+    assert not settings_path.with_suffix(".tmp").exists()
+
+
+def test_load_preferences_handles_missing_and_invalid_files(tmp_path, caplog):
+    missing_path = tmp_path / "missing.json"
+    invalid_path = tmp_path / "invalid.json"
+    invalid_path.write_text("{", encoding="utf-8")
+
+    assert preferences.load_preferences(missing_path) == (
+        preferences.UserPreferences()
+    )
+    assert preferences.load_preferences(invalid_path) == (
+        preferences.UserPreferences()
+    )
+    assert "Could not read preferences" in caplog.text
+
+
+def test_save_preferences_handles_unwritable_path(tmp_path, caplog):
+    blocked_directory = tmp_path / "blocked"
+    blocked_directory.write_text("not a directory", encoding="utf-8")
+
+    assert preferences.save_preferences(
+        preferences.UserPreferences(),
+        blocked_directory / "settings.json",
+    ) is False
+    assert "Could not save preferences" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        None,
+        [1],
+        ["wide", 1],
+        [float("inf"), 1],
+        [0, 1],
+    ],
+)
+def test_invalid_sizes_are_rejected(value):
+    assert preferences._validated_size(value) is None


### PR DESCRIPTION
## Summary
- keep the selection window fixed while adding exact plot-size presets
- persist theme, plot windows, parameter, auto-refresh, and analysis settings
- reflow the Live Monitor without shrinking panels and add fit-to-screen
- switch dense large-text dashboards to compact responsive labels and readouts
- coalesce rapid resize events so window dragging stays responsive

## Tests
- 261 tests with 100.00% configured coverage
- 9 GUI/TUI end-to-end tests
- native resize checks at compact, tall, wide, fit-to-screen, and 200% sizes
- restart persistence and rapid-resize burst checks